### PR TITLE
Update index.ts Body Manual type due to TIS changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {jar} from "./api/client";
 import dayjs from "dayjs";
 
 export interface Manual {
-  type: "em" | "rm" | "bm";
+  type: "em" | "rm" | "cr";
   id: string; // e.g. EM1234
   year?: number; // e.g. 2019
   raw: string; // e.g. EM1234@2019
@@ -59,7 +59,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
       }
       case "BM": {
         genericManuals.push({
-          type: "bm",
+          type: "cr",
           id,
           year,
           raw: m,


### PR DESCRIPTION
Fixed an issue where Body Manuals would not download due to the URL now pointing to /cr/BM... vs /bm/BM...