### PR TITLE
Modernize TIS auth; add legacy + multi-publication manuals, bulletin downloader, helper tools, and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ These manuals are copyrighted by Toyota, so don't share them!
 
 (I've also written a Ford manual downloader, available [here](https://github.com/iamtheyammer/fetch-ford-service-manuals)).
 
+> **📘 Full walkthrough:** Toyota's TIS login has changed since this tool was
+> written, and this fork adds cookie-based authentication, helper tools to
+> extract the session cookie from a HAR (`yarn extract-cookie`), refresh a
+> session by logging in through 2FA (`yarn refresh-session`), and auto-discover
+> a vehicle's manual codes (`yarn lookup-codes`), plus resume support and an
+> archive-packaging step. For a complete, current **setup → authenticate →
+> download → archive** guide (with troubleshooting and a compression-format
+> comparison), see
+> [`docs/downloading-and-zipping-manuals.md`](docs/downloading-and-zipping-manuals.md).
+
 ## Table of Contents
 
 - [Usage](#usage)

--- a/docs/downloading-and-zipping-manuals.md
+++ b/docs/downloading-and-zipping-manuals.md
@@ -263,8 +263,10 @@ don't support it, and has no effect on `EM` (EWD) IDs.
 Older vehicles (e.g. a 2002 Highlander) use **legacy IDs that don't start with
 `RM`/`EM`/`BM`** — such as `OTH021U` (a repair/diagnostic manual) or `EWD470U`
 (a wiring diagram served under the generic `ewd/` path rather than the modern
-`ewdappu` one). For these, give the ID an explicit **`type:` prefix** so the
-tool knows how to fetch it:
+`ewdappu` one). They also tend to **split their service information across
+several standalone publications** beyond the repair manual and wiring diagram.
+For any ID, give it an explicit **`type:` prefix** so the tool knows how to
+fetch it:
 
 | Syntax | Meaning |
 | ------ | ------- |
@@ -272,16 +274,47 @@ tool knows how to fetch it:
 | `bm:<id>` | body manual under the `bm/` path |
 | `ewd:EWD470U` | older wiring diagram under the `ewd/` path |
 | `em:EM36Q0U` | modern EWD (the `ewdappu` format) |
+| `atm:RM836U` | automatic-transmission manual under the `atm/` path |
+| `cr:BRM103U` | collision/body repair manual under the `cr/` path |
+| `ncf:NCF214U` | new car features under the `ncf/` path |
+| `whr:RM1022Ea` | wire-harness repair manual under the `whr/` path |
 
 ```bash
-yarn start -m rm:OTH021U -m ewd:EWD470U
+yarn start -m rm:OTH021U -m ewd:EWD470U -m atm:RM836U \
+  -m cr:BRM103U -m ncf:NCF214U -m whr:RM1022Ea
 ```
+
+`lookup-codes` (above) lists **every** publication a vehicle has, including these
+extra ones — always check it so you don't miss the transmission, body, or
+wire-harness manuals. Note that some legacy IDs are **case-sensitive** (e.g.
+`RM1022Ea` has a lowercase revision suffix); pass them exactly as `lookup-codes`
+prints them.
 
 The tool auto-detects whether each manual is the **modern HTML format** (pages
 rendered to PDF with Playwright) or the **legacy format** (each page is a thin
 xhtml wrapper around a real PDF, downloaded directly over HTTP — no browser),
 and handles both. IDs that already start with `RM`/`EM`/`BM` don't need a
 prefix.
+
+### TSBs, recalls, and other bulletins (`download-documents`)
+
+`lookup-codes` also surfaces a vehicle's **standalone documents** — Service
+Bulletins (TSBs), recall/campaign info (`crib`), diagnostic analysis info
+(`ai`), Quick Training Guides (`qtg`), and more. These are **not** multi-page
+manuals (they have no ToC); each is a single PDF. The main `yarn start`
+downloader only handles manuals, so fetch these with the dedicated tool:
+
+```bash
+# Downloads every standalone document for the vehicle into
+# ./manuals/_documents/<objType>/<publicationNumber>.pdf
+yarn download-documents --model Highlander --year 2002
+# (reads TIS_COOKIE from the environment, or pass --har <path>)
+```
+
+It reuses the same catalog lookup, automatically **skips** the multi-page manual
+publications (download those with `yarn start`), and reports
+`saved/skipped/no-pdf/failed` counts. Re-running is safe — already-downloaded
+PDFs are skipped.
 
 ---
 

--- a/docs/downloading-and-zipping-manuals.md
+++ b/docs/downloading-and-zipping-manuals.md
@@ -1,0 +1,480 @@
+# Downloading Toyota Service Manuals and Producing a Compressed Archive
+
+A practical, end-to-end guide for downloading the full service-manual set for a
+vehicle from Toyota TIS (TechInfo) and packaging it into a single zip archive.
+
+It documents the **cookie/HAR authentication path**, which is the method that
+works against the *current* TIS login. The original tool's email/password login
+no longer completes (see [Authentication](#3-authentication-important) below).
+
+> ⚠️ **Copyright.** These manuals are copyrighted by Toyota. Download only
+> manuals you are entitled to under your own TIS subscription, and do not
+> redistribute them.
+
+---
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [One-time setup](#2-one-time-setup)
+3. [Authentication (important)](#3-authentication-important)
+4. [Finding your manual IDs](#4-finding-your-manual-ids)
+5. [Running the download](#5-running-the-download)
+6. [Verifying completeness](#6-verifying-completeness)
+7. [Producing the output archive](#7-producing-the-output-archive)
+8. [Troubleshooting](#8-troubleshooting)
+9. [Worked example: 2022 Toyota Highlander](#9-worked-example-2022-toyota-highlander)
+
+---
+
+## 1. Prerequisites
+
+- **A valid TIS subscription** — purchase from <https://techinfo.toyota.com>.
+  The 48-hour subscription is sufficient.
+- **A Debian-based Linux host** (Ubuntu, etc.). Commands below assume `apt`.
+- **Node.js ≥ 16.3** with `corepack` available, and `git`, `unzip`, and `zip`.
+
+```bash
+node -v                # must be >= 16.3
+sudo apt-get install -y git unzip zip
+```
+
+---
+
+## 2. One-time setup
+
+### 2.1 Get the code and dependencies
+
+This project's lockfile is **Yarn Classic (v1)** format, so the install must use
+Yarn 1.x. The `packageManager` field in `package.json` pins `yarn@1.22.22`, so
+`corepack` will select it automatically.
+
+```bash
+git clone https://github.com/iamtheyammer/fetch-toyota-service-manuals
+cd fetch-toyota-service-manuals
+corepack enable
+yarn install --frozen-lockfile
+```
+
+### 2.2 Install the Playwright browser (Chromium)
+
+```bash
+yarn playwright install chromium
+```
+
+Then install Chromium's system libraries. On **Ubuntu 24.04+** several libraries
+were renamed with a `t64` suffix, which the pinned Playwright's bundled list
+does not know about. If `playwright install-deps chromium` fails with
+`Package 'libasound2' has no installation candidate`, install the renamed set
+directly:
+
+```bash
+sudo apt-get install -y --no-install-recommends \
+  libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcairo2 \
+  libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 libnspr4 libnss3 \
+  libpango-1.0-0 libwayland-client0 libx11-6 libxcb1 libxcomposite1 libxdamage1 \
+  libxext6 libxfixes3 libxkbcommon0 libxrandr2 xvfb libfontconfig1 libfreetype6 \
+  fonts-liberation fonts-noto-color-emoji fonts-unifont
+```
+
+### 2.3 Known issue: incomplete Chromium extraction on newer Node
+
+The pinned Playwright's bundled unzip can silently extract only a few files of
+the Chromium archive on Node ≥ 24, leaving the browser broken (the `chrome`
+binary missing). Symptom: `browserType.launch: Executable doesn't exist`.
+
+**Fix** — extract the already-downloaded archive with the system `unzip`:
+
+```bash
+# The download succeeds; only the extraction is broken. The zip is left in /tmp.
+DEST=~/.cache/ms-playwright/chromium-1055
+rm -rf "$DEST" && mkdir -p "$DEST"
+unzip -q /tmp/playwright-download-chromium-*-1055.zip -d "$DEST"
+touch "$DEST/INSTALLATION_COMPLETE"
+```
+
+Verify the browser launches:
+
+```bash
+node -e "require('playwright').chromium.launch().then(b=>b.close()).then(()=>console.log('OK'))"
+```
+
+---
+
+## 3. Authentication (important)
+
+> **Email/password login no longer works with this tool.** Toyota replaced the
+> old one-shot OpenAM login with a multi-step ForgeRock journey
+> (username → password → choice → …). The 2022 tool's single header-based login
+> cannot complete it, so the portal bounces to the SSO login page and nothing
+> downloads. Your credentials may be perfectly valid — the *method* is outdated.
+
+Use the **cookie method** instead. Your browser performs the full login
+(including any extra steps / MFA), and you hand the tool the resulting session
+cookie. The tool reuses that exact session.
+
+### 3.1 One session at a time
+
+TIS enforces **one active session per account**. While the tool is downloading:
+
+- Do **not** log in to TIS from another tab/device.
+- Do **not** keep extra TIS tabs open that might refresh and create a competing
+  session.
+
+A concurrent login invalidates the tool's session and you'll see the run abort
+(`concurrentLoginFailure.html`). Re-running resumes (see
+[§5.3](#53-resume-and-session-expiry)), so this is recoverable, but it wastes
+time — keep a single session.
+
+### 3.2 Getting your cookie string
+
+1. Log in to <https://techinfo.toyota.com> in your browser and open any manual
+   page so you are fully inside the portal.
+2. Open **DevTools → Network**.
+3. Reload the page (or click a manual link), then click any request whose domain
+   is **`techinfo.toyota.com`**.
+4. Under **Request Headers**, copy the entire value of the **`Cookie:`** header.
+   It must contain `TISESSIONID=…` (and usually `iPlanetDirectoryPro=…`).
+
+### 3.3 Handing credentials to the tool securely
+
+This fork reads credentials from environment variables, so they never appear in
+the process list (`ps`) or shell history:
+
+| Variable       | Purpose                                  |
+| -------------- | ---------------------------------------- |
+| `TIS_COOKIE`   | Cookie string (recommended)              |
+| `TIS_EMAIL`    | TIS email (legacy login — see warning)   |
+| `TIS_PASSWORD` | TIS password (legacy login — see warning)|
+
+Store the cookie in a private file rather than typing it on the command line:
+
+```bash
+# mktemp creates a fresh owner-only (0600) file; write the cookie into it.
+TIS_ENV="$(mktemp)"
+printf "TIS_COOKIE='%s'\n" 'PASTE_YOUR_COOKIE_STRING_HERE' > "$TIS_ENV"
+set -a; . "$TIS_ENV"; set +a
+rm -f "$TIS_ENV"          # the value now lives only in this shell's environment
+```
+
+The `-c "<cookie>"` / `-e` / `-p` CLI flags from the upstream tool still work if
+you prefer them.
+
+### 3.4 Extracting the cookie from a HAR (`extract-cookie`)
+
+Pulling the `Cookie:` header by hand is fiddly. If you instead export a **HAR**
+of a logged-in TIS session (DevTools → Network → right-click → *Save all as
+HAR*), the bundled tool extracts the session cookie for you:
+
+```bash
+# Print TIS_COOKIE='...' to stdout:
+yarn extract-cookie ~/Downloads/techinfo.toyota.com.har
+
+# Or write it to an owner-only (0600) file and source it:
+TIS_ENV="$(mktemp -u)"   # a fresh path; the tool creates it 0600 and refuses to overwrite an existing file
+yarn extract-cookie ~/Downloads/techinfo.toyota.com.har "$TIS_ENV"
+set -a; . "$TIS_ENV"; set +a; rm -f "$TIS_ENV"
+```
+
+It errors if the HAR has no `TISESSIONID` (i.e. it isn't a logged-in capture).
+
+### 3.5 Refreshing the session by logging in (`refresh-session`)
+
+If you'd rather not export a HAR, this tool logs in for you and emits a fresh
+cookie. Because TIS enforces **two-factor authentication**, it can't be fully
+unattended — it triggers a one-time code to your phone/email and prompts you to
+type it in:
+
+```bash
+export TIS_EMAIL='you@example.com' TIS_PASSWORD='...'
+TIS_ENV="$(mktemp -u)"
+yarn refresh-session --method text --out "$TIS_ENV"
+# -> "Enter the OTP code sent to your device:"  (type the texted code)
+set -a; . "$TIS_ENV"; set +a; rm -f "$TIS_ENV"
+```
+
+- `--method text|email` chooses where the code is sent (default `text`).
+- `--out <file>` writes a `0600` `TIS_COOKIE='...'` file; omit it to print to stdout.
+- `--otp-file <path>` reads the code from a file instead of prompting (lets an
+  orchestrator drop the code in for automation).
+- `--headed` shows the browser (for debugging).
+
+> **Heads-up:** this is a *portal* login, so it rotates the server-side session
+> and supersedes any cookie you captured earlier. Use the resulting cookie for
+> the run you need it for; running `lookup-codes` afterward will rotate it again.
+
+---
+
+## 4. Finding your manual IDs
+
+The tool downloads explicit manual IDs; it has no "list all manuals for a car"
+feature. There are three ID types:
+
+| Prefix | Meaning                          |
+| ------ | -------------------------------- |
+| `RM…`  | Repair Manual                    |
+| `EM…`  | Electrical Wiring Diagram (EWD)  |
+| `BM…`  | Body Manual                      |
+
+To find them, while logged in to TIS:
+
+1. Click the **TIS** tab, select your **Brand / Model / Year**, and **Search**.
+2. Click the **RM** tab, open any document, and read the `RM…` code from the
+   pop-out URL: `…?dir=rm/`**`RM36Q0U`**`&href=…`.
+3. Click the **EWD** tab, open any document, and read the `EM…` code:
+   `…?ewdNo=`**`EM36Q0U`**`&model=…`.
+
+A typical vehicle has **one RM and one EM** (sometimes a BM).
+
+### Auto-discovering codes (`lookup-codes`)
+
+Instead of clicking through TIS by hand, the bundled tool drives the catalog for
+you — it selects the division/model/year, runs the repair search, visits each
+document-type tab (EWD, etc.), and prints every code with the exact `-m` flag to
+pass to the downloader:
+
+```bash
+# Cookie via a logged-in HAR (or set TIS_COOKIE in the environment):
+yarn lookup-codes --model RAV4 --year 2020 --har ~/Downloads/techinfo.toyota.com.har
+```
+
+```
+Codes for TOYOTA RAV4 2020:
+  Repair Manual                RM3510U      -m RM3510U@2020
+  Wiring Diagram (modern EWD)  EM3510U      -m EM3510U
+
+Download all:
+  yarn start -m RM3510U@2020 -m EM3510U
+```
+
+Model names with spaces must be quoted (e.g. `--model "RAV4 HV"`); `--division`
+defaults to `TOYOTA`. The tool fails fast with a clear message if the session is
+expired or has been bumped by a concurrent login (capture a fresh HAR).
+
+### Year filtering
+
+For `RM`/`BM` manuals you can append `@YEAR` to download only pages applicable to
+your model year (e.g. `RM36Q0U@2022`). Many Toyota manuals cover a whole
+generation, so this trims pages for other years. It is harmless on manuals that
+don't support it, and has no effect on `EM` (EWD) IDs.
+
+### Older manuals and the `type:` prefix
+
+Older vehicles (e.g. a 2002 Highlander) use **legacy IDs that don't start with
+`RM`/`EM`/`BM`** — such as `OTH021U` (a repair/diagnostic manual) or `EWD470U`
+(a wiring diagram served under the generic `ewd/` path rather than the modern
+`ewdappu` one). For these, give the ID an explicit **`type:` prefix** so the
+tool knows how to fetch it:
+
+| Syntax | Meaning |
+| ------ | ------- |
+| `rm:OTH021U` | repair manual under the `rm/` path |
+| `bm:<id>` | body manual under the `bm/` path |
+| `ewd:EWD470U` | older wiring diagram under the `ewd/` path |
+| `em:EM36Q0U` | modern EWD (the `ewdappu` format) |
+
+```bash
+yarn start -m rm:OTH021U -m ewd:EWD470U
+```
+
+The tool auto-detects whether each manual is the **modern HTML format** (pages
+rendered to PDF with Playwright) or the **legacy format** (each page is a thin
+xhtml wrapper around a real PDF, downloaded directly over HTTP — no browser),
+and handles both. IDs that already start with `RM`/`EM`/`BM` don't need a
+prefix.
+
+---
+
+## 5. Running the download
+
+### 5.1 The command
+
+With `TIS_COOKIE` exported (see [§3.3](#33-handing-credentials-to-the-tool-securely)):
+
+```bash
+yarn start -m RM36Q0U@2022 -m EM36Q0U
+```
+
+- `-m` may be repeated for multiple manuals.
+- The `start` script sets `NODE_TLS_REJECT_UNAUTHORIZED=0` because Node rejects
+  Toyota's TLS certificate; this is expected and required.
+
+For a long, unattended run, log to a file and run it detached:
+
+```bash
+nohup yarn start -m RM36Q0U@2022 -m EM36Q0U > download.log 2>&1 &
+```
+
+### 5.2 What you get
+
+Output is written under `manuals/<raw-id>/` (the raw id includes any `@YEAR`):
+
+```
+manuals/
+├── RM36Q0U@2022/                 # repair manual
+│   ├── <tree of folders>/*.pdf   # one PDF per manual page, mirroring the TIS sidebar
+│   ├── toc-full.xml              # every available page
+│   ├── toc-downloaded.json       # the (year-filtered) set actually downloaded
+│   ├── toc.js                    # data for the Manual Locator
+│   └── index.html                # Manual Locator (open in a browser)
+└── EM36Q0U/                      # wiring diagrams
+    ├── system/  (svgz/pdf + title.xml/json)
+    ├── routing/ (svgz/pdf + title.xml/json)
+    └── overall/ (pdf + title.xml/json)
+```
+
+Pages are fetched one at a time (to avoid hammering TIS), so a full repair manual
+of several thousand pages can take **a few hours**. The EWD downloads first and
+is comparatively quick.
+
+### 5.3 Resume and session expiry
+
+This fork adds two robustness behaviors for large runs:
+
+- **Resume (skip-existing).** Re-running the *same* command skips any page whose
+  output file already exists, so an interrupted run continues where it left off
+  instead of starting over.
+- **Session-expiry detection.** If the session stops being valid mid-run, TIS
+  returns HTTP 200 with a login page rather than an error. The tool detects this
+  and **aborts cleanly with exit code `2`** instead of silently saving login
+  pages as "manual" content. Grab a fresh cookie and re-run; resume picks up the
+  remaining files.
+
+A handful of individual pages may hit a 30 s navigation timeout; these are logged
+(`Error saving page …`) and skipped. Simply re-run the same command once at the
+end — resume re-fetches only those missing pages.
+
+---
+
+## 6. Verifying completeness
+
+Confirm every page in the (filtered) table of contents has a corresponding file:
+
+```bash
+node -e '
+const fs=require("fs"), path=require("path");
+const base=process.argv[1];
+const toc=JSON.parse(fs.readFileSync(base+"/toc-downloaded.json","utf8"));
+let leaves=0; const missing=[];
+(function walk(o,dir){for(const[k,v] of Object.entries(o)){const n=k.replace(/\//g,"-");
+  if(typeof v==="string"){leaves++;const fp=path.join(dir,n+".pdf");if(!fs.existsSync(fp))missing.push(fp);}
+  else walk(v,path.join(dir,n));}})(toc,base);
+console.log("toc leaves:",leaves,"| present:",leaves-missing.length,"| missing:",missing.length);
+missing.forEach(m=>console.log("  MISSING:",m));
+' "manuals/RM36Q0U@2022"
+```
+
+Also sanity-check that no file is a tiny login-page stub:
+
+```bash
+find manuals -type f ! -name index.html ! -name 'toc*' ! -name 'title.*' -size -512c
+# (no output = good)
+```
+
+---
+
+## 7. Producing the output archive
+
+Package the manuals into a single archive whose **name has no spaces and
+includes the vehicle**.
+
+### Which format? Pick the smallest
+
+The set is dominated by repair-manual PDFs. These are Chromium-generated and
+contain a lot of weakly-compressed text, so a strong compressor helps a lot.
+Measured on this corpus (~1.3 GB on disk):
+
+| Format | Compressor | Size | Notes |
+| ------ | ---------- | ---- | ----- |
+| `.tar.gz` | `gzip -9` | ~831 MB | Most portable; weakest ratio |
+| `.zip` | `zip -1` | ~855 MB | Convenient on Windows; weak ratio |
+| **`.tar.xz`** | **`xz -9e`** | **~587 MB** | **Smallest (~31% smaller than zip/gzip)** |
+| `.tar.zst` | `zstd --ultra -22` | ~600 MB | Nearly as small as xz, faster |
+
+**Use `tar.xz` for the smallest footprint.** `xz -9e -T0` parallelizes across
+all cores; on a 24-core host the full set compresses in ~5 minutes.
+
+### Recommended: tar.xz (smallest)
+
+`tar --transform` rewrites the stored top-level path, so no directory renaming is
+needed:
+
+```bash
+cd fetch-toyota-service-manuals
+
+NAME=2022_Toyota_Highlander_Service_Manuals
+OUT="$HOME/Documents/$NAME.tar.xz"
+
+tar -cf - --transform="s,^manuals,$NAME," manuals | xz -9e -T0 -c > "$OUT"
+
+ls -lh "$OUT"
+```
+
+Verify integrity and that every file is present:
+
+```bash
+xz -t "$OUT" && echo "tar.xz OK"
+echo "archive: $(tar -tJf "$OUT" | grep -vc '/$')   disk: $(find manuals -type f | wc -l)"
+tar -tJf "$OUT" | head -1            # -> 2022_Toyota_Highlander_Service_Manuals/
+```
+
+### Alternatives
+
+```bash
+# tar.gz (most portable; parallel gzip)
+tar -cf - --transform="s,^manuals,$NAME," manuals | pigz -9 > "$HOME/Documents/$NAME.tar.gz"
+
+# zip (Windows-friendly; -1 because the PDFs barely deflate)
+( cd manuals && zip -r -1 -q "$HOME/Documents/$NAME.zip" . )   # note: no wrapper folder
+```
+
+The archive contains a single descriptive top-level folder:
+
+```
+2022_Toyota_Highlander_Service_Manuals/
+├── RM36Q0U@2022/
+└── EM36Q0U/
+```
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause / Fix |
+| ------- | ----------- |
+| `Doesn't appear we're logged into TIS … custom-login-response` | Email/password login is dead on current TIS. Use the cookie method ([§3](#3-authentication-important)). |
+| `… concurrentLoginFailure.html` | Another TIS session is active. Close other TIS tabs/devices, grab a fresh cookie, and re-run (resume continues). |
+| Exit code `2`, "TIS session appears to have expired" | The cookie timed out mid-run. Capture a fresh cookie and re-run the same command; resume re-fetches only what's missing. |
+| `Executable doesn't exist` (Chromium) | Incomplete browser extraction on newer Node — see [§2.3](#23-known-issue-incomplete-chromium-extraction-on-newer-node). |
+| `Package 'libasound2' has no installation candidate` | Ubuntu 24.04+ `t64` library rename — see [§2.2](#22-install-the-playwright-browser-chromium). |
+| A few `Error saving page …: TimeoutError` lines | Transient per-page timeouts. Re-run the same command once; resume grabs the missing pages. |
+| `Manual … doesn't appear to exist` | Wrong ID, or the cookie isn't authenticating. Re-check the `RM…`/`EM…` code and that `TIS_COOKIE` contains a valid `TISESSIONID`. |
+
+---
+
+## 9. Worked example: 2022 Toyota Highlander
+
+IDs: `RM36Q0U` (repair manual), `EM36Q0U` (wiring diagrams).
+
+```bash
+# 1. Authenticate (cookie captured from the browser per §3.2)
+TIS_ENV="$(mktemp)"
+printf "TIS_COOKIE='%s'\n" 'PASTE_COOKIE_HERE' > "$TIS_ENV"
+set -a; . "$TIS_ENV"; set +a; rm -f "$TIS_ENV"
+
+# 2. Download (repair manual filtered to 2022 + full wiring diagrams)
+nohup yarn start -m RM36Q0U@2022 -m EM36Q0U > download.log 2>&1 &
+
+# 3. When finished, re-run once to catch any timed-out pages (resume is automatic)
+yarn start -m RM36Q0U@2022 -m EM36Q0U
+
+# 4. Package as the smallest archive (tar.xz)
+NAME=2022_Toyota_Highlander_Service_Manuals
+OUT="$HOME/Documents/$NAME.tar.xz"
+tar -cf - --transform="s,^manuals,$NAME," manuals | xz -9e -T0 -c > "$OUT"
+xz -t "$OUT" && echo "tar.xz OK ($(du -h "$OUT" | cut -f1))"
+```
+
+Result: a verified `2022_Toyota_Highlander_Service_Manuals.tar.xz` (~587 MB)
+containing the full repair manual (year-filtered to 2022) and the complete
+electrical wiring diagram set.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Sam <iamtheyammer@gmail.com>",
   "license": "GPL-3.0",
   "private": false,
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "axios": "^0.27.2",
     "axios-cookiejar-support": "^4.0.1",
@@ -31,7 +32,10 @@
   "scripts": {
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/index.ts",
     "start:inspect": "NODE_TLS_REJECT_UNAUTHORIZED=0 node -r ts-node/register --inspect-brk src/index.ts",
-    "format": "prettier --write src/**/*.ts",
+    "extract-cookie": "ts-node tools/extractCookie.ts",
+    "lookup-codes": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node tools/lookupCodes.ts",
+    "refresh-session": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node tools/refreshSession.ts",
+    "format": "prettier --write \"src/**/*.ts\" \"tools/**/*.ts\"",
     "playwright-setup": "playwright install chromium && playwright install-deps chromium",
     "watch": "NODE_TLS_REJECT_UNAUTHORIZED=0 nodemon src/index.ts"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start:inspect": "NODE_TLS_REJECT_UNAUTHORIZED=0 node -r ts-node/register --inspect-brk src/index.ts",
     "extract-cookie": "ts-node tools/extractCookie.ts",
     "lookup-codes": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node tools/lookupCodes.ts",
+    "download-documents": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node tools/downloadDocuments.ts",
     "refresh-session": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node tools/refreshSession.ts",
     "format": "prettier --write \"src/**/*.ts\" \"tools/**/*.ts\"",
     "playwright-setup": "playwright install chromium && playwright install-deps chromium",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,19 +4,23 @@ import { CookieJar } from "tough-cookie";
 
 export const jar = new CookieJar();
 
+/** Single source of truth for the TIS host/origin, shared across the client and downloaders. */
+export const TIS_HOST = "techinfo.toyota.com";
+export const TIS_ORIGIN = `https://${TIS_HOST}`;
+
 export const client = wrapper(
   axios.create({
     jar,
-    baseURL: "https://techinfo.toyota.com/t3Portal/external/en/",
+    baseURL: `${TIS_ORIGIN}/t3Portal/external/en/`,
     headers: {
       "User-Agent":
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
       Accept: "text/html, */*; q=0.01",
       "Accept-Language": "en-US,en;q=0.05",
       "Accept-Encoding": "gzip, deflate, br",
-      Origin: "https://techinfo.toyota.com",
+      Origin: TIS_ORIGIN,
       Connection: "keep-alive",
-      Referer: "https://techinfo.toyota.com/",
+      Referer: `${TIS_ORIGIN}/`,
       "Sec-Fetch-Dest": "empty",
       "Sec-Fetch-Mode": "cors",
       "Sec-Fetch-Site": "cross-site",

--- a/src/api/cookies.ts
+++ b/src/api/cookies.ts
@@ -9,19 +9,24 @@ import { jar, TIS_HOST, TIS_ORIGIN } from "./client";
  * the session silently fails.
  */
 export function parseCookieString(cookieString: string): Cookie[] {
-  return cookieString.split("; ").map((c) => {
-    const [name, value] = c.split("=");
-    return {
-      name,
-      value,
-      domain: TIS_HOST,
-      secure: true,
-      sameSite: "None",
-      path: "/",
-      httpOnly: false,
-      expires: dayjs().add(1, "day").unix(),
-    };
-  });
+  return cookieString
+    .split("; ")
+    .filter(Boolean)
+    .map((c) => {
+      // Split on the FIRST "=" only: cookie values can themselves contain "="
+      // (e.g. base64 padding), so a naive split("=") would truncate them.
+      const eq = c.indexOf("=");
+      return {
+        name: c.slice(0, eq),
+        value: c.slice(eq + 1),
+        domain: TIS_HOST,
+        secure: true,
+        sameSite: "None",
+        path: "/",
+        httpOnly: false,
+        expires: dayjs().add(1, "day").unix(),
+      };
+    });
 }
 
 /** Add already-parsed cookies to the shared axios cookie jar. */

--- a/src/api/cookies.ts
+++ b/src/api/cookies.ts
@@ -1,0 +1,40 @@
+import { Cookie } from "playwright";
+import dayjs from "dayjs";
+import { jar, TIS_HOST, TIS_ORIGIN } from "./client";
+
+/**
+ * Parse a raw "name=value; name2=value2" cookie header into Playwright cookie
+ * objects scoped to the TIS host. The `secure` / `SameSite=None` flags are
+ * required -- without them the iPlanetDirectoryPro session cookie isn't sent and
+ * the session silently fails.
+ */
+export function parseCookieString(cookieString: string): Cookie[] {
+  return cookieString.split("; ").map((c) => {
+    const [name, value] = c.split("=");
+    return {
+      name,
+      value,
+      domain: TIS_HOST,
+      secure: true,
+      sameSite: "None",
+      path: "/",
+      httpOnly: false,
+      expires: dayjs().add(1, "day").unix(),
+    };
+  });
+}
+
+/** Add already-parsed cookies to the shared axios cookie jar. */
+export function addCookiesToJar(cookies: Cookie[]): void {
+  for (const c of cookies) {
+    jar.setCookieSync(
+      `${c.name}=${c.value}; Domain=${c.domain}; Path=${c.path}; Expires=${c.expires}; Secure; SameSite=None`,
+      `${TIS_ORIGIN}/t3Portal/`
+    );
+  }
+}
+
+/** Parse a raw cookie header and load it into the shared axios cookie jar. */
+export function setCookieStringOnJar(cookieString: string): void {
+  addCookiesToJar(parseCookieString(cookieString));
+}

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,0 +1,25 @@
+import { existsSync, statSync } from "fs";
+
+/**
+ * Minimum byte sizes below which an already-present file is treated as
+ * incomplete or garbage (a truncated download, or a saved error/login page)
+ * and therefore re-downloaded rather than skipped on a resumed run.
+ *
+ * A genuine manual page PDF is always well over a couple of kilobytes; EWD
+ * figures (svgz/pdf) are smaller but still comfortably above half a kilobyte.
+ */
+export const MIN_VALID_PDF_BYTES = 2048;
+export const MIN_VALID_EWD_FILE_BYTES = 512;
+
+/**
+ * True if `filePath` already exists and is at least `minBytes` in size.
+ *
+ * Used to resume an interrupted download without re-fetching files that
+ * completed on a previous run.
+ */
+export function isAlreadyDownloaded(
+  filePath: string,
+  minBytes: number
+): boolean {
+  return existsSync(filePath) && statSync(filePath).size > minBytes;
+}

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,4 +1,4 @@
-import { client } from "./client";
+import { client, TIS_ORIGIN } from "./client";
 
 /**
  * login logs in with the user's email and password.
@@ -27,6 +27,6 @@ export default async function login(
   // this request sets the session
   await client({
     method: "GET",
-    url: "https://techinfo.toyota.com/t3Portal/",
+    url: `${TIS_ORIGIN}/t3Portal/`,
   });
 }

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -1,0 +1,83 @@
+/**
+ * Helpers for detecting when a TIS session has expired mid-download.
+ *
+ * When the session cookie stops being valid, TIS does not return an error
+ * status -- it returns HTTP 200 with the SSO/login page (for browser
+ * navigations) or an HTML login document (for API/XML requests). Without these
+ * guards the downloader would silently save thousands of login pages as if they
+ * were real manual content, so we detect the condition and abort cleanly.
+ */
+
+/**
+ * True if a Playwright navigation landed on the TIS SSO/login flow instead of
+ * the requested document (i.e. the session is no longer authenticated).
+ *
+ * Detection is URL-based because generic manual *pages* are themselves xhtml,
+ * so sniffing their body for HTML would false-positive. Use this on the
+ * resolved page URL; use {@link looksLikeLoginPage} only for endpoints that
+ * should never return HTML (the EWD XML/PDF/SVGZ endpoints).
+ */
+export function isLoginRedirectUrl(url: string): boolean {
+  return (
+    url.includes("custom-login-response") ||
+    url.includes("/appmanager/") ||
+    url.includes("_pageLabel=ti_home_page") ||
+    url.includes("/openam/") ||
+    url.includes("/agent/custom-login")
+  );
+}
+
+/**
+ * Number of leading characters of a response body inspected when sniffing for
+ * an HTML login page. The login markers always appear at the very top of the
+ * document, so a small prefix is sufficient.
+ */
+const LOGIN_PAGE_SNIFF_LENGTH = 500;
+
+/**
+ * True if a response body that is supposed to be XML/PDF/SVGZ is actually an
+ * HTML login page -- used for the EWD endpoints and the legacy `toc.xml`, which
+ * never legitimately return HTML.
+ *
+ * Do NOT use this on endpoints that legitimately return HTML (e.g. the legacy
+ * xhtml page wrappers) -- it would false-positive on valid content. Use
+ * {@link looksLikeSessionLost} there instead.
+ */
+export function looksLikeLoginPage(body: string): boolean {
+  const head = String(body).slice(0, LOGIN_PAGE_SNIFF_LENGTH).toLowerCase();
+  return (
+    head.includes("<!doctype html") ||
+    head.includes("<html") ||
+    head.includes("custom-login-response")
+  );
+}
+
+/**
+ * True if a response body is one of TIS's specific session-loss pages (expired
+ * session, SSO bounce, or the one-session "concurrent login" guard).
+ *
+ * Unlike {@link looksLikeLoginPage} this does NOT flag generic HTML, so it is
+ * safe on endpoints that legitimately return HTML -- e.g. the legacy xhtml page
+ * wrappers, whose valid content is XHTML.
+ */
+export function looksLikeSessionLost(body: string): boolean {
+  const head = String(body).slice(0, 1500).toLowerCase();
+  return (
+    head.includes("concurrentloginfailure") ||
+    head.includes("custom-login-response") ||
+    head.includes("/openam/") ||
+    head.includes("x-openam") ||
+    head.includes("j_security_check")
+  );
+}
+
+/** Thrown to abort the whole run the moment a session expiry is detected. */
+export class SessionExpiredError extends Error {
+  constructor() {
+    super(
+      "TIS session appears to have expired (redirected to the login page). " +
+        "Grab a fresh cookie and re-run -- already-downloaded files are skipped."
+    );
+    this.name = "SessionExpiredError";
+  }
+}

--- a/src/ewd/index.ts
+++ b/src/ewd/index.ts
@@ -5,6 +5,8 @@ import { AxiosResponse } from "axios";
 import parseTitle from "./parseTitle";
 import saveStream from "../api/saveStream";
 import { Manual } from "..";
+import { looksLikeLoginPage, SessionExpiredError } from "../api/session";
+import { isAlreadyDownloaded, MIN_VALID_EWD_FILE_BYTES } from "../api/files";
 
 export default async function downloadEWD(manualData: Manual, path: string) {
   const parts = ["system", "routing", "overall"];
@@ -44,6 +46,13 @@ export default async function downloadEWD(manualData: Manual, path: string) {
       );
     }
 
+    // If the session expired, the title endpoint returns an HTML login page
+    // (HTTP 200) instead of XML. Detect it at the boundary -- before parsing --
+    // and abort rather than producing empty/garbage output.
+    if (looksLikeLoginPage(titleReq.data)) {
+      throw new SessionExpiredError();
+    }
+
     const files = await parseTitle(titleReq.data);
 
     // write to disk
@@ -59,6 +68,13 @@ export default async function downloadEWD(manualData: Manual, path: string) {
       const fileExt = path.split(".")[1];
       const isPdf = fileExt === "pdf";
 
+      const filePath = join(partPath, `${fileName}.${fileExt}`);
+
+      // Resume support: skip files already downloaded in a previous run.
+      if (isAlreadyDownloaded(filePath, MIN_VALID_EWD_FILE_BYTES)) {
+        continue;
+      }
+
       console.log(
         `Downloading ${manualData.id} ${part} ${fileName} as ${fileExt}...`
       );
@@ -71,12 +87,14 @@ export default async function downloadEWD(manualData: Manual, path: string) {
         responseType: isPdf ? "stream" : "text",
       });
 
-      const filePath = join(partPath, `${fileName}.${fileExt}`);
       if (isPdf) {
         // response is stream, save as such
         await saveStream(fileReq.data, filePath);
       } else {
         // file isn't a stream, just write the text to disk
+        if (looksLikeLoginPage(fileReq.data)) {
+          throw new SessionExpiredError();
+        }
         await writeFile(filePath, fileReq.data);
       }
     }

--- a/src/ewd/index.ts
+++ b/src/ewd/index.ts
@@ -9,21 +9,24 @@ import { looksLikeLoginPage, SessionExpiredError } from "../api/session";
 import { isAlreadyDownloaded, MIN_VALID_EWD_FILE_BYTES } from "../api/files";
 
 export default async function downloadEWD(manualData: Manual, path: string) {
-  const parts = ["system", "routing", "overall"];
+  // The content sections an EWD can expose. Not every vehicle has every part
+  // (older EWDs lack "intro"/"fuselist"/"connlist"; some lack "overall"), so a
+  // 404 on a single part is skipped rather than treated as a fatal "wrong id"
+  // error -- that error is only raised if NO part is found at all.
+  const parts = [
+    "intro",
+    "system",
+    "routing",
+    "fuselist",
+    "connlist",
+    "overall",
+  ];
+
+  let foundAnyPart = false;
 
   // download
-  for (const partIdx in parts) {
-    const part = parts[partIdx];
+  for (const part of parts) {
     const partPath = join(path, part);
-
-    // create directory
-    try {
-      await mkdir(partPath, { recursive: true });
-    } catch (e: any) {
-      if (e.code !== "EEXIST") {
-        throw new Error(`Error creating directory ${path}: ${e}`);
-      }
-    }
 
     // download ToC "title"
     let titleReq: AxiosResponse;
@@ -36,13 +39,12 @@ export default async function downloadEWD(manualData: Manual, path: string) {
       });
     } catch (e: any) {
       if (e.response && e.response.status === 404) {
-        throw new Error(
-          `EWD ${manualData.id} doesn't appear to exist-- are you sure the ID is right?`
-        );
+        // This part doesn't exist for this vehicle; skip it.
+        continue;
       }
 
       throw new Error(
-        `Unknown error getting title XML for EWD ${manualData.id}: ${e}`
+        `Unknown error getting title XML for EWD ${manualData.id} part ${part}: ${e}`
       );
     }
 
@@ -53,7 +55,17 @@ export default async function downloadEWD(manualData: Manual, path: string) {
       throw new SessionExpiredError();
     }
 
+    foundAnyPart = true;
     const files = await parseTitle(titleReq.data);
+
+    // create directory (only now that we know the part exists)
+    try {
+      await mkdir(partPath, { recursive: true });
+    } catch (e: any) {
+      if (e.code !== "EEXIST") {
+        throw new Error(`Error creating directory ${partPath}: ${e}`);
+      }
+    }
 
     // write to disk
     await writeFile(join(partPath, "title.xml"), titleReq.data);
@@ -98,5 +110,13 @@ export default async function downloadEWD(manualData: Manual, path: string) {
         await writeFile(filePath, fileReq.data);
       }
     }
+  }
+
+  // No part responded -- the id is almost certainly wrong (a real EWD always
+  // has at least "system").
+  if (!foundAnyPart) {
+    throw new Error(
+      `EWD ${manualData.id} doesn't appear to exist-- are you sure the ID is right?`
+    );
   }
 }

--- a/src/ewd/parseTitle.ts
+++ b/src/ewd/parseTitle.ts
@@ -43,9 +43,20 @@ export default async function parseTitle(
     ignoreDeclaration: true,
   });
 
-  // @ts-ignore - xml2js compact doesn't seem to work well with TS
-  // this gives us the big list of figures
-  const data: TitleElement[] = Object.values(xmlobj.TitleList)[1];
+  // The figure entries live under the first non-metadata child of <TitleList>
+  // (e.g. <System> for system/overall, <Routing> for routing). xml-js prefixes
+  // metadata keys with "_" (_attributes, _instruction, _declaration, _doctype).
+  // Newer TIS XML adds an <?controldate?> instruction, so we can't rely on a
+  // fixed positional index (the old `Object.values(TitleList)[1]` broke on it).
+  // The child may be an array (many entries) or a single object (one entry).
+  const titleList: any = (xmlobj as any).TitleList || {};
+  const entriesKey = Object.keys(titleList).find((k) => !k.startsWith("_"));
+  const rawEntries = entriesKey ? titleList[entriesKey] : undefined;
+  const data: TitleElement[] = Array.isArray(rawEntries)
+    ? rawEntries
+    : rawEntries
+    ? [rawEntries]
+    : [];
 
   const parsedTitle: ParsedTitle = {};
 

--- a/src/genericManual/index.ts
+++ b/src/genericManual/index.ts
@@ -1,59 +1,24 @@
-import { AxiosResponse } from "axios";
-import { client } from "../api/client";
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir } from "fs/promises";
 import { join } from "path";
-import parseToC, { ParsedToC } from "./parseToC";
 import { Page } from "playwright";
-import { Manual } from "..";
+import { TIS_ORIGIN } from "../api/client";
+import { ParsedToC } from "./parseToC";
+import { isLoginRedirectUrl, SessionExpiredError } from "../api/session";
+import { isAlreadyDownloaded, MIN_VALID_PDF_BYTES } from "../api/files";
+import { sanitizeName } from "../manual/toc";
 
+/**
+ * Download a modern manual whose pages are HTML documents, rendering each to a
+ * PDF with Playwright. The (already fetched and saved) parsed ToC is supplied
+ * by the caller; see `fetchAndSaveToc`.
+ */
 export default async function downloadGenericManual(
   page: Page,
-  manualData: Manual,
+  toc: ParsedToC,
   path: string
 ) {
-  // download ToC
-  let tocReq: AxiosResponse;
-  try {
-    console.log("Downloading table of contents...");
-    tocReq = await client({
-      method: "GET",
-      url: `${manualData.type}/${manualData.id}/toc.xml`,
-      // we don't want axios to parse this
-      responseType: "text",
-    });
-  } catch (e: any) {
-    if (e.response && e.response.status === 404) {
-      throw new Error(
-        `Manual ${manualData.id} doesn't appear to exist-- are you sure the ID is right?`
-      );
-    }
-
-    throw new Error(
-      `Unknown error getting title XML for manual ${manualData.raw}: ${e}`
-    );
-  }
-
-  const files = parseToC(tocReq.data, manualData.year);
-
-  // write to disk
-  console.log("Saving table of contents...");
-  await Promise.all([
-    writeFile(join(path, "toc-full.xml"), tocReq.data),
-    writeFile(
-      join(path, "toc-downloaded.json"),
-      JSON.stringify(files, null, 2)
-    ),
-    writeFile(
-      join(path, "toc.js"),
-      `document.toc = JSON.parse(\`${JSON.stringify(files).replaceAll(
-        '\\"',
-        ""
-      )}\`);`
-    ),
-  ]);
-
   console.log("Downloading full manual...");
-  await recursivelyDownloadManual(page, path, files);
+  await recursivelyDownloadManual(page, path, toc);
 }
 
 async function recursivelyDownloadManual(
@@ -61,57 +26,43 @@ async function recursivelyDownloadManual(
   path: string,
   toc: ParsedToC
 ) {
-  const exploded = Object.entries(toc);
-
-  for (const explIdx in exploded) {
-    const [name, value] = exploded[explIdx];
-
+  for (const [name, value] of Object.entries(toc)) {
     if (typeof value === "string") {
-      const sanitizedName = name.replace(/\//g, "-");
-      const sanitizedPath = `${join(path, sanitizedName)}.pdf`;
-      console.log(`Downloading page ${sanitizedName}...`);
+      const sanitizedName = sanitizeName(name);
+      const pdfPath = `${join(path, sanitizedName)}.pdf`;
 
-      // download page
+      // Resume support: skip pages already downloaded in a previous run.
+      if (isAlreadyDownloaded(pdfPath, MIN_VALID_PDF_BYTES)) {
+        continue;
+      }
+
+      console.log(`Downloading page ${sanitizedName}...`);
       try {
-        await page.goto(`https://techinfo.toyota.com${value}`, {
-          waitUntil: "load",
-        });
+        await page.goto(`${TIS_ORIGIN}${value}`, { waitUntil: "load" });
+        // If the session expired, TIS redirects to the login page (HTTP 200)
+        // instead of the document. Abort rather than save a login page as a PDF.
+        if (isLoginRedirectUrl(page.url())) {
+          throw new SessionExpiredError();
+        }
         await page.addScriptTag({
           content: `document.querySelector(".footer").remove()`,
         });
         await page.pdf({
-          path: sanitizedPath,
-          margin: {
-            top: 1,
-            right: 1,
-            bottom: 1,
-            left: 1,
-          },
+          path: pdfPath,
+          margin: { top: 1, right: 1, bottom: 1, left: 1 },
         });
       } catch (e) {
+        // A session expiry is fatal for the whole run; let it propagate.
+        if (e instanceof SessionExpiredError) throw e;
         console.error(`Error saving page ${name}: ${e}`);
-        continue;
       }
 
-      // downloaded page, move on
       continue;
     }
 
-    // we're not at the bottom of the tree, continue
-
-    // create folder
-    const newPath = join(path, name.replace(/\//g, "-"));
-    if (newPath.includes("undefined")) debugger;
-    try {
-      await mkdir(newPath, { recursive: true });
-    } catch (e) {
-      if ((e as any).code === "EEXIST") {
-        console.log(
-          `Not creating folder ${newPath} because it already exists.`
-        );
-      }
-    }
-
-    await recursivelyDownloadManual(page, newPath, value);
+    // Not a leaf: recurse into the sub-tree.
+    const branchPath = join(path, sanitizeName(name));
+    await mkdir(branchPath, { recursive: true });
+    await recursivelyDownloadManual(page, branchPath, value);
   }
 }

--- a/src/genericManual/parseToC.ts
+++ b/src/genericManual/parseToC.ts
@@ -30,7 +30,16 @@ export default function parseToC(
   const bookTitle: string = xmlobj.xmltoc.name._text;
 
   // @ts-ignore - see above
-  const bookItems: ItemElement[] = xmlobj.xmltoc.item;
+  const rawBookItems: ItemElement | ItemElement[] = xmlobj.xmltoc.item;
+
+  // Compact XML parsing yields a bare object (not an array) when <xmltoc> has a
+  // single top-level <item> -- as some legacy publications (e.g. the wire-harness
+  // manual RM1022Ea) do. Normalise to an array so the iteration below holds for
+  // both shapes; getItemPath() already handles the single-vs-array case deeper in
+  // the tree.
+  const bookItems: ItemElement[] = Array.isArray(rawBookItems)
+    ? rawBookItems
+    : [rawBookItems];
 
   const toc: ParsedToC = {};
 
@@ -40,7 +49,16 @@ export default function parseToC(
     itemPath.forEach((ip) => {
       // add item to the ToC, final object's value is the path, key is the filename
       const itemDest = recursivelyAccessObject(ip.path, toc);
-      itemDest[ip.filename] = ip.url;
+      // Two sibling leaves can carry an identical display name while pointing at
+      // distinct pages (e.g. the 2002 Highlander repair manual has two different
+      // "...EGR Flow Excessive Monitor (P0402)" pages in one folder). Keying the
+      // ToC purely by name would let the second silently overwrite the first and
+      // drop a page, so disambiguate with a numeric suffix when the key is taken.
+      let key = ip.filename;
+      for (let n = 2; key in itemDest; n++) {
+        key = `${ip.filename} (${n})`;
+      }
+      itemDest[key] = ip.url;
     });
   });
 

--- a/src/genericManual/parseToC.ts
+++ b/src/genericManual/parseToC.ts
@@ -186,7 +186,19 @@ function recursivelyAccessObject(
   keys: string[],
   obj: { [any: string]: any }
 ): { [any: string]: string } {
-  if (!obj[keys[0]]) {
+  const existing = obj[keys[0]];
+  if (typeof existing === "string") {
+    // A folder shares a name with an earlier sibling leaf (a distinct page that
+    // happens to share this folder's title). Descending would overwrite/By the
+    // string and throw; instead relocate the leaf under a disambiguated key so
+    // it survives, then create the folder in its place.
+    let moved = `${keys[0]} (page)`;
+    for (let n = 2; moved in obj; n++) {
+      moved = `${keys[0]} (page ${n})`;
+    }
+    obj[moved] = existing;
+    obj[keys[0]] = {};
+  } else if (!existing) {
     obj[keys[0]] = {};
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,17 +12,30 @@ import { SessionExpiredError } from "./api/session";
 import dayjs from "dayjs";
 
 export interface Manual {
-  // Path prefix / downloader selector. "em" -> modern EWD (ewdappu); "rm"/"bm"
-  // -> repair/body manual; "ewd" -> older wiring diagram served under the
-  // generic "ewd/" path. "rm"/"bm"/"ewd" share the generic toc.xml format.
-  type: "em" | "rm" | "bm" | "ewd";
+  // Path prefix / downloader selector. "em" -> modern EWD (ewdappu); all other
+  // types share the generic "<type>/<id>/toc.xml" format and route through the
+  // generic/legacy downloader: "rm" -> repair manual, "bm" -> body manual,
+  // "ewd" -> older wiring diagram, "atm" -> automatic transmission manual,
+  // "cr" -> collision/body repair manual, "ncf" -> new car features,
+  // "whr" -> wire harness repair manual. The last four are common on older
+  // vehicles, which split content across several standalone publications.
+  type: "em" | "rm" | "bm" | "ewd" | "atm" | "cr" | "ncf" | "whr";
   id: string; // e.g. EM1234
   year?: number; // e.g. 2019
   raw: string; // e.g. EM1234@2019
 }
 
 /** All accepted explicit `-m <type>:<id>` type prefixes. */
-const MANUAL_TYPES = ["rm", "bm", "em", "ewd"] as const;
+const MANUAL_TYPES = [
+  "rm",
+  "bm",
+  "em",
+  "ewd",
+  "atm",
+  "cr",
+  "ncf",
+  "whr",
+] as const;
 
 /**
  * Infer a manual type from an ID's leading characters, for IDs given without an
@@ -47,7 +60,12 @@ async function run({ manual, email, password, headed, cookieString }: CLIArgs) {
   const ewds: Manual[] = [];
   const genericManuals: Manual[] = [];
 
-  const rawManualIds = new Set(manual.map((m) => m.toUpperCase().trim()));
+  // Preserve the user-supplied case of each spec: most publication IDs are
+  // all-uppercase, but some legacy ones carry a case-sensitive revision suffix
+  // (e.g. the wire-harness manual "RM1022Ea"), and Toyota's endpoints are
+  // case-sensitive. Type-prefix matching and prefix autodetection normalise
+  // case themselves below, so no blanket upper-casing is needed here.
+  const rawManualIds = new Set(manual.map((m) => m.trim()));
 
   console.log("Parsing manual IDs...");
   rawManualIds.forEach((m) => {
@@ -98,9 +116,17 @@ async function run({ manual, email, password, headed, cookieString }: CLIArgs) {
         genericManuals.push({ type: "ewd", id, year, raw });
         return;
       }
+      case "atm":
+      case "cr":
+      case "ncf":
+      case "whr": {
+        genericManuals.push({ type, id, year, raw });
+        return;
+      }
       default: {
         console.error(
-          `Invalid manual ${m}: prefix the ID with a type (rm:/bm:/em:/ewd:) ` +
+          `Invalid manual ${m}: prefix the ID with a type ` +
+            `(rm:/bm:/em:/ewd:/atm:/cr:/ncf:/whr:) ` +
             `or use an ID starting with EM, RM, or BM.`
         );
         process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,15 +42,20 @@ const MANUAL_TYPES = [
  * Infer a manual type from an ID's leading characters, for IDs given without an
  * explicit `type:` prefix. Returns undefined for unrecognized prefixes (older
  * IDs like OTH021U / EWD470U must be given an explicit type).
+ *
+ * Note: `BM####` body/collision manuals are now served under the `cr/` path
+ * (TIS moved them from `bm/`), so a bare `BM` id autodetects to `cr`. The
+ * explicit `bm:` prefix remains available as a fallback for any manual still on
+ * the old path.
  */
-function autodetectType(id: string): "em" | "rm" | "bm" | undefined {
+function autodetectType(id: string): "em" | "rm" | "cr" | undefined {
   switch (id.slice(0, 2).toUpperCase()) {
     case "EM":
       return "em";
     case "RM":
       return "rm";
     case "BM":
-      return "bm";
+      return "cr";
     default:
       return undefined;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,48 @@
-import processCLIArgs, {CLIArgs} from "./processCLIArgs";
+import processCLIArgs, { CLIArgs } from "./processCLIArgs";
 import login from "./api/login";
-import {join, resolve} from "path";
-import {mkdir, readFile, writeFile} from "fs/promises";
+import { join, resolve } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import downloadEWD from "./ewd";
 import downloadGenericManual from "./genericManual";
-import {chromium, Cookie} from "playwright";
-import {jar} from "./api/client";
+import downloadLegacyManual, { isLegacyPdfManual } from "./legacyManual";
+import { fetchAndSaveToc } from "./manual/toc";
+import { chromium, Cookie } from "playwright";
+import { jar, TIS_HOST, TIS_ORIGIN } from "./api/client";
+import { SessionExpiredError } from "./api/session";
 import dayjs from "dayjs";
 
 export interface Manual {
-  type: "em" | "rm" | "bm";
+  // Path prefix / downloader selector. "em" -> modern EWD (ewdappu); "rm"/"bm"
+  // -> repair/body manual; "ewd" -> older wiring diagram served under the
+  // generic "ewd/" path. "rm"/"bm"/"ewd" share the generic toc.xml format.
+  type: "em" | "rm" | "bm" | "ewd";
   id: string; // e.g. EM1234
   year?: number; // e.g. 2019
   raw: string; // e.g. EM1234@2019
 }
 
-async function run({manual, email, password, headed, cookieString}: CLIArgs) {
+/** All accepted explicit `-m <type>:<id>` type prefixes. */
+const MANUAL_TYPES = ["rm", "bm", "em", "ewd"] as const;
+
+/**
+ * Infer a manual type from an ID's leading characters, for IDs given without an
+ * explicit `type:` prefix. Returns undefined for unrecognized prefixes (older
+ * IDs like OTH021U / EWD470U must be given an explicit type).
+ */
+function autodetectType(id: string): "em" | "rm" | "bm" | undefined {
+  switch (id.slice(0, 2).toUpperCase()) {
+    case "EM":
+      return "em";
+    case "RM":
+      return "rm";
+    case "BM":
+      return "bm";
+    default:
+      return undefined;
+  }
+}
+
+async function run({ manual, email, password, headed, cookieString }: CLIArgs) {
   // sort manuals and make sure that they're valid (ish)
   const ewds: Manual[] = [];
   const genericManuals: Manual[] = [];
@@ -24,51 +51,57 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
 
   console.log("Parsing manual IDs...");
   rawManualIds.forEach((m) => {
-    const id = m.includes("@") ? m.split("@")[0] : m;
-    const year = m.includes("@") ? parseInt(m.split("@")[1]) : undefined;
+    // Optional explicit type prefix, e.g. "rm:OTH021U" or "ewd:EWD470U@2002".
+    // Needed for older manuals whose IDs don't start with RM/EM/BM, and whose
+    // wiring diagrams live under the generic "ewd/" path (not modern ewdappu).
+    let explicitType: string | undefined;
+    let spec = m;
+    const colonIdx = m.indexOf(":");
+    if (colonIdx > 0) {
+      const prefix = m.slice(0, colonIdx).toLowerCase();
+      if ((MANUAL_TYPES as readonly string[]).includes(prefix)) {
+        explicitType = prefix;
+        spec = m.slice(colonIdx + 1);
+      }
+    }
 
-    if (year && year !== -1) {
+    const id = spec.includes("@") ? spec.split("@")[0] : spec;
+    const year = spec.includes("@") ? parseInt(spec.split("@")[1]) : undefined;
+    const raw = spec; // directory name (id + optional @year), without type prefix
+
+    if (year !== undefined && year !== -1) {
       if (isNaN(year)) {
         console.error(`Invalid manual ${m}: the model year must be a number.`);
         process.exit(1);
       } else {
         console.log(
-          `Detected a manual with a year: ${m} (${year}). We'll try to download only manual pages that pertain to that year, but can't guarantee that it'll work.`
+          `Detected a manual with a year: ${raw} (${year}). We'll try to download only manual pages that pertain to that year, but can't guarantee that it'll work.`
         );
       }
     }
 
-    switch (m.slice(0, 2).toUpperCase()) {
-      case "EM": {
-        ewds.push({
-          type: "em",
-          id,
-          year,
-          raw: m,
-        });
+    const type = explicitType || autodetectType(id);
+    switch (type) {
+      case "em": {
+        ewds.push({ type: "em", id, year, raw });
         return;
       }
-      case "RM": {
-        genericManuals.push({
-          type: "rm",
-          id,
-          year,
-          raw: m,
-        });
+      case "rm": {
+        genericManuals.push({ type: "rm", id, year, raw });
         return;
       }
-      case "BM": {
-        genericManuals.push({
-          type: "bm",
-          id,
-          year,
-          raw: m,
-        });
+      case "bm": {
+        genericManuals.push({ type: "bm", id, year, raw });
+        return;
+      }
+      case "ewd": {
+        genericManuals.push({ type: "ewd", id, year, raw });
         return;
       }
       default: {
         console.error(
-          `Invalid manual ${m}: manual IDs must start with EM, RM, or BM.`
+          `Invalid manual ${m}: prefix the ID with a type (rm:/bm:/em:/ewd:) ` +
+            `or use an ID starting with EM, RM, or BM.`
         );
         process.exit(1);
       }
@@ -85,7 +118,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
 
   try {
     await Promise.all(
-      Object.values(dirPaths).map((m) => mkdir(m, {recursive: true}))
+      Object.values(dirPaths).map((m) => mkdir(m, { recursive: true }))
     );
   } catch (e: any) {
     if (e.code !== "EEXIST") {
@@ -95,13 +128,19 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
   }
 
   // copy accessor into manuals
-  console.log("Copying accessor into manuals...")
+  console.log("Copying accessor into manuals...");
   try {
-    const accessorHTML = await readFile(join(__dirname, "..", "accessor/index.html"), "utf-8");
+    const accessorHTML = await readFile(
+      join(__dirname, "..", "accessor/index.html"),
+      "utf-8"
+    );
     await Promise.all(
-      Object.values(dirPaths).map((m) => writeFile(join(m, "index.html"), accessorHTML)));
+      Object.values(dirPaths).map((m) =>
+        writeFile(join(m, "index.html"), accessorHTML)
+      )
+    );
   } catch (e) {
-    console.error("Unable to copy accessor file into manuals.", e)
+    console.error("Unable to copy accessor file into manuals.", e);
   }
 
   console.log("Setting up Playwright...");
@@ -125,7 +164,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
     transformedCookies = jar.toJSON().cookies.map((c) => ({
       name: c.key,
       value: c.value,
-      domain: "techinfo.toyota.com",
+      domain: TIS_HOST,
       // for some reason, we have to do this-- otherwise, the iPlanetDirectoryPro
       // cookie isn't sent, which means that the session isn't working
       secure: true,
@@ -146,7 +185,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
       return {
         name,
         value,
-        domain: "techinfo.toyota.com",
+        domain: TIS_HOST,
         // for some reason, we have to do this-- otherwise, the iPlanetDirectoryPro
         // cookie isn't sent, which means that the session isn't working
         secure: true,
@@ -161,7 +200,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
     transformedCookies.forEach((c) => {
       jar.setCookieSync(
         `${c.name}=${c.value}; Domain=${c.domain}; Path=${c.path}; Expires=${c.expires}; Secure; SameSite=None`,
-        "https://techinfo.toyota.com/t3Portal/"
+        `${TIS_ORIGIN}/t3Portal/`
       );
     });
   } else {
@@ -181,7 +220,7 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
   });
 
   console.log("Checking that Playwright is logged in...");
-  const resp = await page.goto("https://techinfo.toyota.com/t3Portal/", {
+  const resp = await page.goto(`${TIS_ORIGIN}/t3Portal/`, {
     waitUntil: "commit",
   });
   if (!resp || !resp.url().endsWith("t3Portal/")) {
@@ -200,12 +239,23 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
     await downloadEWD(ewd, dirPaths[ewd.id]);
   }
 
-  // download other manuals - requires playwright
+  // download other manuals - generic format. The ToC is fetched and saved once
+  // here, then passed to the appropriate downloader. Older manuals serve each
+  // page as a direct PDF (downloaded via axios); modern ones are HTML rendered
+  // to PDF via Playwright. Detect which per manual and dispatch accordingly.
   for (const manualIdx in genericManuals) {
     const manual = genericManuals[manualIdx];
+    const path = dirPaths[manual.id];
 
-    console.log(`Downloading ${manual.raw}... (type = generic)`);
-    await downloadGenericManual(page, manual, dirPaths[manual.id]);
+    console.log(`Downloading ${manual.raw}...`);
+    const toc = await fetchAndSaveToc(manual, path);
+
+    if (await isLegacyPdfManual(toc)) {
+      console.log(`${manual.raw} is a legacy PDF manual.`);
+      await downloadLegacyManual(toc, path);
+    } else {
+      await downloadGenericManual(page, toc, path);
+    }
   }
 
   console.log("All manuals downloaded!");
@@ -213,4 +263,11 @@ async function run({manual, email, password, headed, cookieString}: CLIArgs) {
 }
 
 const args = processCLIArgs();
-run(args);
+run(args).catch((e) => {
+  if (e instanceof SessionExpiredError) {
+    console.error(`\n${e.message}`);
+    process.exit(2);
+  }
+  console.error(e);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import downloadLegacyManual, { isLegacyPdfManual } from "./legacyManual";
 import { fetchAndSaveToc } from "./manual/toc";
 import { chromium, Cookie } from "playwright";
 import { jar, TIS_HOST, TIS_ORIGIN } from "./api/client";
+import { addCookiesToJar, parseCookieString } from "./api/cookies";
 import { SessionExpiredError } from "./api/session";
 import dayjs from "dayjs";
 
@@ -203,32 +204,10 @@ async function run({ manual, email, password, headed, cookieString }: CLIArgs) {
   } else if (cookieString) {
     console.log("Using cookies from command line...");
 
-    // parse cookie string
-    const cookieStrings = cookieString.split("; ");
-    // transform cookie strings into cookie objects
-    transformedCookies = cookieStrings.map((c) => {
-      const [name, value] = c.split("=");
-      return {
-        name,
-        value,
-        domain: TIS_HOST,
-        // for some reason, we have to do this-- otherwise, the iPlanetDirectoryPro
-        // cookie isn't sent, which means that the session isn't working
-        secure: true,
-        sameSite: "None",
-        path: "/",
-        httpOnly: false,
-        expires: dayjs().add(1, "day").unix(),
-      };
-    });
-
-    // add cookies to axios jar
-    transformedCookies.forEach((c) => {
-      jar.setCookieSync(
-        `${c.name}=${c.value}; Domain=${c.domain}; Path=${c.path}; Expires=${c.expires}; Secure; SameSite=None`,
-        `${TIS_ORIGIN}/t3Portal/`
-      );
-    });
+    // Parse the cookie header into Playwright cookies (for the browser context)
+    // and load the same set into the axios jar (for the HTTP downloaders).
+    transformedCookies = parseCookieString(cookieString);
+    addCookiesToJar(transformedCookies);
   } else {
     console.log(
       "No credentials provided. Please provide either a cookie string or email/password."

--- a/src/legacyManual/index.ts
+++ b/src/legacyManual/index.ts
@@ -57,6 +57,48 @@ export default async function downloadLegacyManual(
   await recursivelyDownloadLegacyManual(path, toc);
 }
 
+/**
+ * Fetch a single legacy document's xhtml wrapper, follow the PDF link it
+ * contains, and save that PDF to pdfPath. Shared by the legacy-manual
+ * downloader (one call per ToC leaf) and the standalone document downloader
+ * (`tools/downloadDocuments.ts`, one call per TSB/bulletin), which serve PDFs
+ * through the identical wrapper mechanism. The caller owns skip-existing and
+ * logging so it can tally outcomes as it sees fit.
+ *
+ * @returns true if a PDF was saved, false if the wrapper had no PDF link.
+ * @throws {SessionExpiredError} if the wrapper is a session-loss page.
+ */
+export async function downloadLegacyDocumentPdf(
+  wrapperHref: string,
+  pdfPath: string
+): Promise<boolean> {
+  // 1. Fetch the xhtml wrapper to discover the PDF it points to. The wrapper is
+  //    legitimately HTML, so detect session loss with the precise check rather
+  //    than the generic "is this HTML?" one.
+  const wrapper = await client({
+    method: "GET",
+    url: `${TIS_ORIGIN}${wrapperHref}${DOC_SUFFIX}`,
+    responseType: "text",
+  });
+
+  const pdfHref = extractPdfHref(String(wrapper.data));
+  if (!pdfHref) {
+    if (looksLikeSessionLost(String(wrapper.data))) {
+      throw new SessionExpiredError();
+    }
+    return false;
+  }
+
+  // 2. Download the PDF itself.
+  const pdfReq = await client({
+    method: "GET",
+    url: `${TIS_ORIGIN}${pdfHref}${DOC_SUFFIX}`,
+    responseType: "stream",
+  });
+  await saveStream(pdfReq.data, pdfPath);
+  return true;
+}
+
 async function recursivelyDownloadLegacyManual(path: string, toc: ParsedToC) {
   for (const [name, value] of Object.entries(toc)) {
     if (typeof value === "string") {
@@ -69,31 +111,10 @@ async function recursivelyDownloadLegacyManual(path: string, toc: ParsedToC) {
 
       console.log(`Downloading page ${sanitizeName(name)}...`);
       try {
-        // 1. Fetch the xhtml wrapper to discover the PDF it points to. The
-        //    wrapper is legitimately HTML, so detect session loss with the
-        //    precise check rather than the generic "is this HTML?" one.
-        const wrapper = await client({
-          method: "GET",
-          url: `${TIS_ORIGIN}${value}${DOC_SUFFIX}`,
-          responseType: "text",
-        });
-
-        const pdfHref = extractPdfHref(String(wrapper.data));
-        if (!pdfHref) {
-          if (looksLikeSessionLost(String(wrapper.data))) {
-            throw new SessionExpiredError();
-          }
+        const saved = await downloadLegacyDocumentPdf(value, pdfPath);
+        if (!saved) {
           console.error(`No PDF link found for page ${name}, skipping.`);
-          continue;
         }
-
-        // 2. Download the PDF itself.
-        const pdfReq = await client({
-          method: "GET",
-          url: `${TIS_ORIGIN}${pdfHref}${DOC_SUFFIX}`,
-          responseType: "stream",
-        });
-        await saveStream(pdfReq.data, pdfPath);
       } catch (e) {
         // A session expiry is fatal for the whole run; let it propagate.
         if (e instanceof SessionExpiredError) throw e;

--- a/src/legacyManual/index.ts
+++ b/src/legacyManual/index.ts
@@ -1,0 +1,135 @@
+import { mkdir } from "fs/promises";
+import { join } from "path";
+import { client, TIS_ORIGIN } from "../api/client";
+import { ParsedToC } from "../genericManual/parseToC";
+import saveStream from "../api/saveStream";
+import { looksLikeSessionLost, SessionExpiredError } from "../api/session";
+import { isAlreadyDownloaded, MIN_VALID_PDF_BYTES } from "../api/files";
+import { sanitizeName } from "../manual/toc";
+
+/**
+ * Older TIS manuals (e.g. the 2002-era repair manuals and `EWD###U` wiring
+ * diagrams) use the generic `toc.xml` tree, but each leaf "page" is a thin
+ * xhtml wrapper that redirects to a real, downloadable PDF -- unlike modern
+ * manuals whose pages are HTML rendered to PDF with Playwright. This module
+ * downloads those PDFs directly over HTTP (no browser required).
+ */
+
+// Every legacy document URL (xhtml wrapper and PDF alike) must carry this query
+// suffix; without it the server returns a client-side locale/siid bootstrap
+// redirect instead of the terminal content.
+const DOC_SUFFIX = "?sisuffix=ff&locale=en";
+
+/**
+ * True if a manual is the legacy PDF-wrapper format (each leaf links to a
+ * downloadable PDF) rather than the modern HTML-rendered format. Detected by
+ * sampling the manual's first leaf page.
+ *
+ * @throws {SessionExpiredError} if the sampled page is a session-loss page.
+ */
+export async function isLegacyPdfManual(toc: ParsedToC): Promise<boolean> {
+  const firstHref = firstLeafHref(toc);
+  if (!firstHref) return false;
+
+  const wrapper = await client({
+    method: "GET",
+    url: `${TIS_ORIGIN}${firstHref}${DOC_SUFFIX}`,
+    responseType: "text",
+  });
+  const html = String(wrapper.data);
+  if (extractPdfHref(html) !== undefined) return true;
+
+  // No PDF link: either a modern HTML page, or the session was lost mid-detect.
+  if (looksLikeSessionLost(html)) throw new SessionExpiredError();
+  return false;
+}
+
+/**
+ * Download a legacy manual by fetching each page's linked PDF directly. The
+ * (already fetched and saved) parsed ToC is supplied by the caller; see
+ * `fetchAndSaveToc`.
+ */
+export default async function downloadLegacyManual(
+  toc: ParsedToC,
+  path: string
+) {
+  console.log("Downloading full manual (legacy PDF format)...");
+  await recursivelyDownloadLegacyManual(path, toc);
+}
+
+async function recursivelyDownloadLegacyManual(path: string, toc: ParsedToC) {
+  for (const [name, value] of Object.entries(toc)) {
+    if (typeof value === "string") {
+      const pdfPath = `${join(path, sanitizeName(name))}.pdf`;
+
+      // Resume support: skip pages already downloaded in a previous run.
+      if (isAlreadyDownloaded(pdfPath, MIN_VALID_PDF_BYTES)) {
+        continue;
+      }
+
+      console.log(`Downloading page ${sanitizeName(name)}...`);
+      try {
+        // 1. Fetch the xhtml wrapper to discover the PDF it points to. The
+        //    wrapper is legitimately HTML, so detect session loss with the
+        //    precise check rather than the generic "is this HTML?" one.
+        const wrapper = await client({
+          method: "GET",
+          url: `${TIS_ORIGIN}${value}${DOC_SUFFIX}`,
+          responseType: "text",
+        });
+
+        const pdfHref = extractPdfHref(String(wrapper.data));
+        if (!pdfHref) {
+          if (looksLikeSessionLost(String(wrapper.data))) {
+            throw new SessionExpiredError();
+          }
+          console.error(`No PDF link found for page ${name}, skipping.`);
+          continue;
+        }
+
+        // 2. Download the PDF itself.
+        const pdfReq = await client({
+          method: "GET",
+          url: `${TIS_ORIGIN}${pdfHref}${DOC_SUFFIX}`,
+          responseType: "stream",
+        });
+        await saveStream(pdfReq.data, pdfPath);
+      } catch (e) {
+        // A session expiry is fatal for the whole run; let it propagate.
+        if (e instanceof SessionExpiredError) throw e;
+        console.error(`Error saving page ${name}: ${e}`);
+      }
+
+      continue;
+    }
+
+    // Not a leaf: recurse into the sub-tree.
+    const branchPath = join(path, sanitizeName(name));
+    await mkdir(branchPath, { recursive: true });
+    await recursivelyDownloadLegacyManual(branchPath, value);
+  }
+}
+
+/**
+ * Extract the PDF URL that a legacy wrapper page redirects to, from either its
+ * `<link rel="pdf" href="...">` element or its `location="....pdf"` script.
+ */
+function extractPdfHref(html: string): string | undefined {
+  const link =
+    html.match(/<link[^>]+rel=["']pdf["'][^>]*href=["']([^"']+)["']/i) ||
+    html.match(/<link[^>]+href=["']([^"']+)["'][^>]*rel=["']pdf["']/i);
+  if (link) return link[1];
+
+  const loc = html.match(/location\s*=\s*["']([^"']+\.pdf[^"']*)["']/i);
+  return loc ? loc[1] : undefined;
+}
+
+/** Depth-first search for the first leaf (string) value in a parsed ToC. */
+function firstLeafHref(toc: ParsedToC): string | undefined {
+  for (const value of Object.values(toc)) {
+    if (typeof value === "string") return value;
+    const nested = firstLeafHref(value);
+    if (nested) return nested;
+  }
+  return undefined;
+}

--- a/src/manual/toc.ts
+++ b/src/manual/toc.ts
@@ -1,0 +1,78 @@
+import { AxiosResponse } from "axios";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import { client } from "../api/client";
+import parseToC, { ParsedToC } from "../genericManual/parseToC";
+import { looksLikeLoginPage, SessionExpiredError } from "../api/session";
+import { Manual } from "..";
+
+/**
+ * Shared table-of-contents handling for both the modern (HTML) and legacy (PDF)
+ * manual downloaders. Centralizing it keeps the ToC fetch, the friendly
+ * "doesn't exist" 404 message, and the (non-obvious) `toc.js` serialization in
+ * a single place, and lets the manual be fetched once per run rather than once
+ * per detection plus once per download.
+ */
+
+/** Make a ToC entry name safe to use as a single file/directory path segment. */
+export function sanitizeName(name: string): string {
+  return name.replace(/\//g, "-");
+}
+
+/**
+ * Fetch a manual's table of contents, persist it (`toc-full.xml`,
+ * `toc-downloaded.json`, and `toc.js` for the Manual Locator), and return the
+ * parsed, year-filtered tree.
+ *
+ * @throws a friendly error if the manual ID doesn't exist (HTTP 404).
+ * @throws {SessionExpiredError} if the ToC endpoint returns a login page.
+ */
+export async function fetchAndSaveToc(
+  manualData: Manual,
+  path: string
+): Promise<ParsedToC> {
+  let tocReq: AxiosResponse;
+  try {
+    console.log("Downloading table of contents...");
+    tocReq = await client({
+      method: "GET",
+      url: `${manualData.type}/${manualData.id}/toc.xml`,
+      // we don't want axios to parse this
+      responseType: "text",
+    });
+  } catch (e: any) {
+    if (e.response && e.response.status === 404) {
+      throw new Error(
+        `Manual ${manualData.id} doesn't appear to exist-- are you sure the ID is right?`
+      );
+    }
+    throw new Error(
+      `Unknown error getting table of contents for ${manualData.raw}: ${e}`
+    );
+  }
+
+  // The ToC is XML; an HTML response means TIS bounced us to the login page.
+  if (looksLikeLoginPage(tocReq.data)) {
+    throw new SessionExpiredError();
+  }
+
+  const files = parseToC(tocReq.data, manualData.year);
+
+  console.log("Saving table of contents...");
+  await Promise.all([
+    writeFile(join(path, "toc-full.xml"), tocReq.data),
+    writeFile(
+      join(path, "toc-downloaded.json"),
+      JSON.stringify(files, null, 2)
+    ),
+    writeFile(
+      join(path, "toc.js"),
+      `document.toc = JSON.parse(\`${JSON.stringify(files).replaceAll(
+        '\\"',
+        ""
+      )}\`);`
+    ),
+  ]);
+
+  return files;
+}

--- a/src/processCLIArgs.ts
+++ b/src/processCLIArgs.ts
@@ -98,22 +98,24 @@ export default function processCLIArgs(): CLIArgs {
       process.exit(0);
     }
 
-    if (
-      !options.manual ||
-      ((!options.email || !options.password) && !options["cookie-string"])
-    ) {
-      console.error("Missing required args!");
-      // console.log(options);
+    // Resolve each credential from its CLI flag, falling back to the matching
+    // env var, then validate -- so any valid mix (e.g. CLI email + env
+    // password) is accepted consistently with how it is used.
+    const email = options.email || process.env.TIS_EMAIL;
+    const password = options.password || process.env.TIS_PASSWORD;
+    const cookieString = options["cookie-string"] || process.env.TIS_COOKIE;
 
+    if (!options.manual || ((!email || !password) && !cookieString)) {
+      console.error("Missing required args!");
       console.log(usage);
       process.exit(1);
     }
     return {
       manual: options.manual,
-      email: options.email,
-      password: options.password,
+      email,
+      password,
       headed: options.headed,
-      cookieString: options["cookie-string"],
+      cookieString,
     };
   } catch (e: any) {
     console.error(e);

--- a/tools/downloadDocuments.ts
+++ b/tools/downloadDocuments.ts
@@ -1,0 +1,136 @@
+import commandLineArgs from "command-line-args";
+import { join, resolve } from "path";
+import { mkdir } from "fs/promises";
+import { collectDocuments, FoundDoc } from "./lookupCodes";
+import { resolveCookieString } from "./lib/harCookie";
+import { setCookieStringOnJar } from "../src/api/cookies";
+import { downloadLegacyDocumentPdf } from "../src/legacyManual";
+import { isAlreadyDownloaded, MIN_VALID_PDF_BYTES } from "../src/api/files";
+import { sanitizeName } from "../src/manual/toc";
+import { SessionExpiredError } from "../src/api/session";
+
+/**
+ * Download every standalone document (TSB, recall/campaign bulletin, diagnostic
+ * info, quick-training guide, …) that TIS lists for a vehicle. These are NOT the
+ * multi-page manuals handled by the main downloader (`yarn start`): each is a
+ * single document served as an xhtml wrapper that redirects to one PDF -- the
+ * same mechanism as a legacy manual leaf, but with no ToC. We reuse the catalog
+ * scraper from lookupCodes to enumerate them and the legacy PDF fetcher to save
+ * each one.
+ *
+ * Usage:
+ *   TIS_COOKIE='...' ts-node tools/downloadDocuments.ts --model Highlander --year 2002
+ *   ts-node tools/downloadDocuments.ts --model Highlander --year 2002 --har ~/Downloads/techinfo.har
+ *
+ * Files are written to `<out>/<objType>/<publicationNumber>.pdf` (default out:
+ * ./manuals/_documents). Multi-page manual publications are skipped -- fetch
+ * those with the main downloader (`yarn start -m <type>:<id>`).
+ */
+
+// objTypes that are multi-page manuals (have a toc.xml) rather than single
+// standalone documents. These are downloaded by the main `yarn start` flow, so
+// this tool skips them.
+const MANUAL_OBJ_TYPES = new Set([
+  "rm",
+  "bm",
+  "em",
+  "ewd",
+  "ewdappu",
+  "atm",
+  "cr",
+  "ncf",
+  "whr",
+]);
+
+/** The xhtml wrapper href for a standalone document, relative to the host. */
+function wrapperHref(doc: FoundDoc): string {
+  return `/t3Portal/document/${doc.type}/${doc.publicationNumber}/xhtml/${doc.publicationNumber}.html`;
+}
+
+async function main() {
+  const opts = commandLineArgs([
+    { name: "model", type: String },
+    { name: "year", type: String },
+    { name: "division", type: String, defaultValue: "TOYOTA" },
+    { name: "har", type: String },
+    {
+      name: "out",
+      type: String,
+      defaultValue: join(".", "manuals", "_documents"),
+    },
+  ]);
+
+  if (!opts.model || !opts.year) {
+    console.error(
+      "Usage: ts-node tools/downloadDocuments.ts --model <Model> --year <Year> " +
+        "[--division TOYOTA] [--har <har-path>] [--out <dir>]"
+    );
+    process.exit(2);
+  }
+
+  const cookieString = resolveCookieString(opts.har);
+  setCookieStringOnJar(cookieString);
+
+  console.log(
+    `Looking up documents for ${opts.division} ${opts.model} ${opts.year}...`
+  );
+  const allDocs = await collectDocuments(
+    { division: opts.division, model: opts.model, year: opts.year },
+    cookieString
+  );
+
+  const docs = allDocs.filter((d) => !MANUAL_OBJ_TYPES.has(d.type));
+  const skippedManuals = allDocs.length - docs.length;
+  console.log(
+    `Found ${allDocs.length} documents; ${docs.length} standalone ` +
+      `(skipping ${skippedManuals} multi-page manual publications -- use the main downloader for those).`
+  );
+
+  let saved = 0;
+  let skipped = 0;
+  let noPdf = 0;
+  let failed = 0;
+
+  for (const doc of docs) {
+    const dir = resolve(opts.out, doc.type);
+    await mkdir(dir, { recursive: true });
+    const pdfPath = join(dir, `${sanitizeName(doc.publicationNumber)}.pdf`);
+
+    if (isAlreadyDownloaded(pdfPath, MIN_VALID_PDF_BYTES)) {
+      skipped++;
+      continue;
+    }
+
+    console.log(`Downloading ${doc.type}/${doc.publicationNumber}...`);
+    try {
+      const ok = await downloadLegacyDocumentPdf(wrapperHref(doc), pdfPath);
+      if (ok) {
+        saved++;
+      } else {
+        noPdf++;
+        console.error(
+          `  No PDF link for ${doc.type}/${doc.publicationNumber}.`
+        );
+      }
+    } catch (e) {
+      if (e instanceof SessionExpiredError) throw e;
+      failed++;
+      console.error(`  Error on ${doc.type}/${doc.publicationNumber}: ${e}`);
+    }
+  }
+
+  console.log(
+    `\nDone. saved=${saved} skipped(existing)=${skipped} no-pdf=${noPdf} failed=${failed} ` +
+      `(of ${docs.length} standalone documents).`
+  );
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  if (e instanceof SessionExpiredError) {
+    console.error(`\n${e.message}`);
+    process.exit(2);
+  }
+  console.error("ERROR:", e.message ?? e);
+  process.exit(1);
+});

--- a/tools/downloadDocuments.ts
+++ b/tools/downloadDocuments.ts
@@ -1,7 +1,7 @@
 import commandLineArgs from "command-line-args";
 import { join, resolve } from "path";
 import { mkdir } from "fs/promises";
-import { collectDocuments, FoundDoc } from "./lookupCodes";
+import { collectDocuments, FoundDoc, MANUAL_OBJ_TYPES } from "./lookupCodes";
 import { resolveCookieString } from "./lib/harCookie";
 import { setCookieStringOnJar } from "../src/api/cookies";
 import { downloadLegacyDocumentPdf } from "../src/legacyManual";
@@ -16,31 +16,16 @@ import { SessionExpiredError } from "../src/api/session";
  * single document served as an xhtml wrapper that redirects to one PDF -- the
  * same mechanism as a legacy manual leaf, but with no ToC. We reuse the catalog
  * scraper from lookupCodes to enumerate them and the legacy PDF fetcher to save
- * each one.
+ * each one. Multi-page manual publications (MANUAL_OBJ_TYPES) are skipped --
+ * fetch those with the main downloader (`yarn start -m <type>:<id>`).
  *
  * Usage:
  *   TIS_COOKIE='...' ts-node tools/downloadDocuments.ts --model Highlander --year 2002
  *   ts-node tools/downloadDocuments.ts --model Highlander --year 2002 --har ~/Downloads/techinfo.har
  *
  * Files are written to `<out>/<objType>/<publicationNumber>.pdf` (default out:
- * ./manuals/_documents). Multi-page manual publications are skipped -- fetch
- * those with the main downloader (`yarn start -m <type>:<id>`).
+ * ./manuals/_documents).
  */
-
-// objTypes that are multi-page manuals (have a toc.xml) rather than single
-// standalone documents. These are downloaded by the main `yarn start` flow, so
-// this tool skips them.
-const MANUAL_OBJ_TYPES = new Set([
-  "rm",
-  "bm",
-  "em",
-  "ewd",
-  "ewdappu",
-  "atm",
-  "cr",
-  "ncf",
-  "whr",
-]);
 
 /** The xhtml wrapper href for a standalone document, relative to the host. */
 function wrapperHref(doc: FoundDoc): string {

--- a/tools/extractCookie.ts
+++ b/tools/extractCookie.ts
@@ -1,0 +1,32 @@
+import { cookieStringFromHar, emitCookie } from "./lib/harCookie";
+
+/**
+ * Extract the TIS session cookie from a browser-exported HAR file so it can be
+ * fed to the downloader (via the `TIS_COOKIE` env var or the `-c` flag).
+ *
+ * Usage:
+ *   ts-node tools/extractCookie.ts <har-path>                 # print TIS_COOKIE='...' to stdout
+ *   ts-node tools/extractCookie.ts <har-path> <out-env-file>  # write it to a 0600 file to `source`
+ *
+ * The env-file form is preferred: it keeps the cookie out of your shell history
+ * and process listings. Example:
+ *   ts-node tools/extractCookie.ts ~/Downloads/techinfo.har /tmp/tis.env
+ *   set -a; . /tmp/tis.env; set +a; rm -f /tmp/tis.env
+ */
+function main(): void {
+  const [harPath, outPath] = process.argv.slice(2);
+  if (!harPath) {
+    console.error(
+      "Usage: ts-node tools/extractCookie.ts <har-path> [out-env-file]"
+    );
+    process.exit(2);
+  }
+
+  const { cookieString, names } = cookieStringFromHar(harPath);
+  emitCookie(cookieString, outPath);
+  if (outPath) {
+    console.error(`Cookies: ${names.join(", ")}`);
+  }
+}
+
+main();

--- a/tools/lib/harCookie.ts
+++ b/tools/lib/harCookie.ts
@@ -1,0 +1,147 @@
+import { readFileSync, writeFileSync } from "fs";
+import { TIS_HOST } from "../../src/api/client";
+
+/**
+ * Helpers for reusing a logged-in TIS browser session captured as a HAR file.
+ * The downloader and the catalog-lookup tool both authenticate by replaying the
+ * `techinfo.toyota.com` cookies the browser sent, rather than performing a
+ * (now-unsupported) scripted login.
+ */
+
+/** A Playwright storage-state cookie scoped to the TIS host. */
+export interface PlaywrightCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  secure: boolean;
+  sameSite: "None";
+  httpOnly: boolean;
+  expires: number;
+}
+
+/** One day from now, in seconds (Playwright cookie expiry). */
+function oneDayFromNow(): number {
+  return Math.floor(Date.now() / 1000) + 86400;
+}
+
+/**
+ * Parse the `techinfo.toyota.com` session cookies out of a browser-exported HAR
+ * file (the cookies sent on requests to the TIS host).
+ *
+ * @returns the assembled `name=value; ...` cookie string and the cookie names.
+ * @throws if no `TISESSIONID` is present (the HAR isn't a logged-in TIS session).
+ */
+export function cookieStringFromHar(harPath: string): {
+  cookieString: string;
+  names: string[];
+} {
+  const har = JSON.parse(readFileSync(harPath, "utf8"));
+  const jar: Record<string, string> = {};
+  for (const entry of har.log?.entries ?? []) {
+    let host = "";
+    try {
+      host = new URL(entry.request.url).host;
+    } catch {
+      continue;
+    }
+    if (host !== TIS_HOST) continue;
+    const header = (entry.request.headers ?? []).find(
+      (h: any) => h.name.toLowerCase() === "cookie"
+    );
+    if (header?.value) {
+      for (const pair of String(header.value).split(/;\s*/)) {
+        const eq = pair.indexOf("=");
+        if (eq > 0) jar[pair.slice(0, eq)] = pair.slice(eq + 1);
+      }
+    }
+  }
+
+  const names = Object.keys(jar);
+  if (!names.includes("TISESSIONID")) {
+    throw new Error(
+      `No TISESSIONID cookie found in ${harPath} -- is it a logged-in TIS session capture?`
+    );
+  }
+  return {
+    cookieString: names.map((n) => `${n}=${jar[n]}`).join("; "),
+    names,
+  };
+}
+
+/**
+ * Build Playwright storage-state cookies (scoped to the TIS host) from a
+ * `name=value; ...` cookie string.
+ */
+export function playwrightCookiesFromString(
+  cookieString: string
+): PlaywrightCookie[] {
+  return cookieString
+    .split("; ")
+    .filter(Boolean)
+    .map((c) => {
+      const eq = c.indexOf("=");
+      return {
+        name: c.slice(0, eq),
+        value: c.slice(eq + 1),
+        domain: TIS_HOST,
+        path: "/",
+        secure: true,
+        sameSite: "None",
+        httpOnly: false,
+        expires: oneDayFromNow(),
+      };
+    });
+}
+
+/**
+ * Resolve a cookie string from either a HAR path or the `TIS_COOKIE` env var.
+ * @throws if neither source yields a cookie.
+ */
+export function resolveCookieString(harPath?: string): string {
+  if (harPath) return cookieStringFromHar(harPath).cookieString;
+  if (process.env.TIS_COOKIE) return process.env.TIS_COOKIE;
+  throw new Error(
+    "No TIS cookie: pass --har <path> to a logged-in HAR, or set TIS_COOKIE."
+  );
+}
+
+/** Assemble a `name=value; ...` cookie string from Playwright cookie records. */
+export function cookieStringFromPlaywright(
+  cookies: { name: string; value: string }[]
+): string {
+  return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+}
+
+/**
+ * Emit a `TIS_COOKIE='...'` shell line for the given cookie string: to a
+ * private file at `outPath`, or to stdout when no path is given.
+ *
+ * When writing a file it uses an **exclusive create** (`flag: "wx"`) so the
+ * `0600` mode is actually applied (Node ignores `mode` on an existing file) and
+ * a session credential never lands in a pre-existing, possibly world-readable or
+ * attacker-controlled file. It refuses (throws) rather than overwrite.
+ */
+export function emitCookie(cookieString: string, outPath?: string): void {
+  // Single-quote for shell `source`; strip any quotes from the value itself.
+  const line = `TIS_COOKIE='${cookieString.replace(/'/g, "")}'\n`;
+
+  if (!outPath) {
+    process.stdout.write(line);
+    return;
+  }
+
+  try {
+    writeFileSync(outPath, line, { flag: "wx", mode: 0o600 });
+  } catch (e: any) {
+    if (e.code === "EEXIST") {
+      throw new Error(
+        `Refusing to write the session cookie to existing file ${outPath} -- ` +
+          `remove it first (its permissions/owner cannot be trusted).`
+      );
+    }
+    throw e;
+  }
+  // Diagnostics to stderr so stdout stays clean if it is being captured.
+  process.stderr.write(`Wrote TIS_COOKIE to ${outPath}\n`);
+}

--- a/tools/lib/harCookie.ts
+++ b/tools/lib/harCookie.ts
@@ -8,23 +8,6 @@ import { TIS_HOST } from "../../src/api/client";
  * (now-unsupported) scripted login.
  */
 
-/** A Playwright storage-state cookie scoped to the TIS host. */
-export interface PlaywrightCookie {
-  name: string;
-  value: string;
-  domain: string;
-  path: string;
-  secure: boolean;
-  sameSite: "None";
-  httpOnly: boolean;
-  expires: number;
-}
-
-/** One day from now, in seconds (Playwright cookie expiry). */
-function oneDayFromNow(): number {
-  return Math.floor(Date.now() / 1000) + 86400;
-}
-
 /**
  * Parse the `techinfo.toyota.com` session cookies out of a browser-exported HAR
  * file (the cookies sent on requests to the TIS host).
@@ -67,31 +50,6 @@ export function cookieStringFromHar(harPath: string): {
     cookieString: names.map((n) => `${n}=${jar[n]}`).join("; "),
     names,
   };
-}
-
-/**
- * Build Playwright storage-state cookies (scoped to the TIS host) from a
- * `name=value; ...` cookie string.
- */
-export function playwrightCookiesFromString(
-  cookieString: string
-): PlaywrightCookie[] {
-  return cookieString
-    .split("; ")
-    .filter(Boolean)
-    .map((c) => {
-      const eq = c.indexOf("=");
-      return {
-        name: c.slice(0, eq),
-        value: c.slice(eq + 1),
-        domain: TIS_HOST,
-        path: "/",
-        secure: true,
-        sameSite: "None",
-        httpOnly: false,
-        expires: oneDayFromNow(),
-      };
-    });
 }
 
 /**

--- a/tools/lookupCodes.ts
+++ b/tools/lookupCodes.ts
@@ -37,6 +37,11 @@ interface FoundDoc {
   publicationNumber: string;
 }
 
+/** Extract the `_pageLabel` value from a TIS portal URL, or "" if absent. */
+function pageLabelOf(url: string): string {
+  return (url.match(/_pageLabel=([^&]+)/) || [])[1] || "";
+}
+
 /** Pull distinct {objType, publicationNumber} pairs out of result-link hrefs. */
 function parseDocsFromHrefs(hrefs: (string | null)[]): FoundDoc[] {
   const seen = new Map<string, FoundDoc>();
@@ -177,17 +182,29 @@ async function main() {
 
     collect(await docsOnPage(page));
 
-    // Visit every other document-type tab (lib_<type>_page) and scrape it too.
-    const currentUrl = page.url();
+    // Visit every other document-type library tab (lib_<type>_page) and scrape
+    // it too. A heavily-bulletined vehicle (e.g. an older Prius) can expose
+    // hundreds of result links that all share the same handful of tab
+    // pageLabels -- they differ only by pagination / per-document query params.
+    // De-dupe by the `_pageLabel` value, not the full href, keeping one
+    // representative per real tab; visiting every href would open hundreds of
+    // pages and eventually crash the browser.
+    const currentLabel = pageLabelOf(page.url());
     const tabHrefs: string[] = await page
       .$$eval("a[href]", (as) =>
-        as
-          .map((a) => (a as HTMLAnchorElement).href)
+        (as as HTMLAnchorElement[])
+          .map((a) => a.href)
           .filter((h) => /_pageLabel=lib_[a-z]+_page/.test(h))
       )
       .catch(() => []);
-    const uniqueTabs = [...new Set(tabHrefs)].filter((h) => h !== currentUrl);
-    for (const href of uniqueTabs) {
+    const tabByLabel = new Map<string, string>();
+    for (const href of tabHrefs) {
+      const label = pageLabelOf(href);
+      if (label && label !== currentLabel && !tabByLabel.has(label)) {
+        tabByLabel.set(label, href);
+      }
+    }
+    for (const href of tabByLabel.values()) {
       await page.goto(href, { waitUntil: "domcontentloaded" }).catch(() => {});
       await page.waitForTimeout(SETTLE_MS);
       collect(await docsOnPage(page));

--- a/tools/lookupCodes.ts
+++ b/tools/lookupCodes.ts
@@ -1,9 +1,7 @@
 import commandLineArgs from "command-line-args";
 import { chromium, Page } from "playwright";
-import {
-  playwrightCookiesFromString,
-  resolveCookieString,
-} from "./lib/harCookie";
+import { resolveCookieString } from "./lib/harCookie";
+import { parseCookieString } from "../src/api/cookies";
 import { TIS_ORIGIN } from "../src/api/client";
 
 /**
@@ -43,6 +41,24 @@ export interface VehicleSelector {
   model: string;
   year: string;
 }
+
+/**
+ * objTypes that are multi-page manuals (each backed by a `toc.xml`) and so are
+ * downloaded by the main `yarn start` flow. Every other objType is a standalone
+ * single-PDF document (TSB, recall, bulletin, …) handled by
+ * `tools/downloadDocuments.ts`. Single source of truth for that split.
+ */
+export const MANUAL_OBJ_TYPES = new Set([
+  "rm",
+  "bm",
+  "em",
+  "ewd",
+  "ewdappu",
+  "atm",
+  "cr",
+  "ncf",
+  "whr",
+]);
 
 /** Extract the `_pageLabel` value from a TIS portal URL, or "" if absent. */
 function pageLabelOf(url: string): string {
@@ -122,6 +138,13 @@ function downloaderFlag(type: string, pub: string, year: string): string {
       return `-m ewd:${pub}`;
     case "bm":
       return upper2 === "BM" ? `-m ${pub}@${year}` : `-m bm:${pub}@${year}`;
+    case "atm":
+    case "cr":
+    case "ncf":
+    case "whr":
+      // Older standalone manual publications: explicit type prefix, no year
+      // filter (they're single-purpose and downloaded in full).
+      return `-m ${type}:${pub}`;
     default:
       return `-m ${pub}`;
   }
@@ -142,7 +165,7 @@ export async function collectDocuments(
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({
     storageState: {
-      cookies: playwrightCookiesFromString(cookieString),
+      cookies: parseCookieString(cookieString),
       origins: [],
     },
   });
@@ -249,17 +272,44 @@ async function main() {
     return;
   }
 
-  const flags: string[] = [];
+  // Manuals (multi-page, fetched by `yarn start`) and standalone documents
+  // (single PDFs, fetched by `yarn download-documents`) need different tools, so
+  // list and summarise them separately.
+  const manualFlags: string[] = [];
+  let bulletinCount = 0;
   for (const [type, set] of [...byType.entries()].sort()) {
+    const isManual = MANUAL_OBJ_TYPES.has(type);
     for (const pub of [...set].sort()) {
-      const flag = downloaderFlag(type, pub, opts.year);
-      flags.push(flag.replace(/^-m /, ""));
-      console.log(`  ${typeLabel(type).padEnd(28)} ${pub.padEnd(12)} ${flag}`);
+      if (isManual) {
+        const flag = downloaderFlag(type, pub, opts.year);
+        manualFlags.push(flag.replace(/^-m /, ""));
+        console.log(
+          `  ${typeLabel(type).padEnd(28)} ${pub.padEnd(14)} ${flag}`
+        );
+      } else {
+        bulletinCount++;
+        console.log(
+          `  ${typeLabel(type).padEnd(28)} ${pub.padEnd(14)} (bulletin)`
+        );
+      }
     }
   }
-  console.log(
-    `\nDownload all:\n  yarn start ${flags.map((f) => `-m ${f}`).join(" ")}`
-  );
+
+  if (manualFlags.length) {
+    console.log(
+      `\nDownload the manuals:\n  yarn start ${manualFlags
+        .map((f) => `-m ${f}`)
+        .join(" ")}`
+    );
+  }
+  if (bulletinCount) {
+    console.log(
+      `\nDownload the ${bulletinCount} standalone document(s) (TSBs, recalls, ` +
+        `bulletins):\n  yarn download-documents --model "${opts.model}" ` +
+        `--year ${opts.year}` +
+        (opts.division !== "TOYOTA" ? ` --division "${opts.division}"` : "")
+    );
+  }
 }
 
 // Only run the CLI when invoked directly (e.g. `ts-node tools/lookupCodes.ts`),

--- a/tools/lookupCodes.ts
+++ b/tools/lookupCodes.ts
@@ -118,6 +118,12 @@ function typeLabel(type: string): string {
       return "Wiring Diagram (legacy)";
     case "bm":
       return "Body/Collision Manual";
+    case "cr":
+      return "Collision/Body Repair Manual";
+    case "atm":
+      return "Automatic Transmission Manual";
+    case "whr":
+      return "Wire Harness Repair Manual";
     case "ncf":
       return "New Car Features";
     default:

--- a/tools/lookupCodes.ts
+++ b/tools/lookupCodes.ts
@@ -1,0 +1,222 @@
+import commandLineArgs from "command-line-args";
+import { chromium, Page } from "playwright";
+import {
+  playwrightCookiesFromString,
+  resolveCookieString,
+} from "./lib/harCookie";
+import { TIS_ORIGIN } from "../src/api/client";
+
+/**
+ * Look up the publication codes (Repair Manual, EWD, Body Manual, …) for a
+ * given vehicle by driving the TIS catalog: it selects the division/model/year
+ * on the repair-search form, then visits each document-type tab and scrapes the
+ * `publicationNumber`/`objType` off the result links.
+ *
+ * Usage:
+ *   TIS_COOKIE='...' ts-node tools/lookupCodes.ts --model RAV4 --year 2020
+ *   ts-node tools/lookupCodes.ts --model "RAV4 HV" --year 2020 --har ~/Downloads/techinfo.har
+ *
+ * Output lists each code with the exact `-m` flag to pass to the downloader.
+ */
+
+const TIS_CATALOG_URL = `${TIS_ORIGIN}/t3Portal/appmanager/t3/ti?_nfpb=true&_pageLabel=t3_tis`;
+
+// WebLogic portlet-mangled field names on the repair-search form.
+const FIELD = {
+  division: "repairformwlw-select_key:{actionForm.division}",
+  model: "repairformwlw-select_key:{actionForm.model}",
+  year: "repairformwlw-select_key:{actionForm.year}",
+};
+
+// How long to let the cascading dropdowns / search settle after an interaction.
+const SETTLE_MS = 2500;
+const SEARCH_SETTLE_MS = 4000;
+
+interface FoundDoc {
+  type: string; // objType, e.g. "rm", "ewdappu", "bm"
+  publicationNumber: string;
+}
+
+/** Pull distinct {objType, publicationNumber} pairs out of result-link hrefs. */
+function parseDocsFromHrefs(hrefs: (string | null)[]): FoundDoc[] {
+  const seen = new Map<string, FoundDoc>();
+  for (const href of hrefs) {
+    if (!href) continue;
+    const pub = (href.match(/publicationNumber=([^&]+)/) || [])[1];
+    if (!pub) continue;
+    const type =
+      (href.match(/objType=([^&]+)/) || [])[1] ||
+      (href.match(/[?&]dir=([a-z]+)/) || [])[1] ||
+      "?";
+    const publicationNumber = decodeURIComponent(pub);
+    seen.set(`${type}:${publicationNumber}`, { type, publicationNumber });
+  }
+  return [...seen.values()];
+}
+
+/** Collect document links across every frame of the current page. */
+async function docsOnPage(page: Page): Promise<FoundDoc[]> {
+  let hrefs: (string | null)[] = [];
+  for (const frame of page.frames()) {
+    const frameHrefs = await frame
+      .$$eval("a[href]", (as) => as.map((a) => a.getAttribute("href")))
+      .catch(() => [] as (string | null)[]);
+    hrefs = hrefs.concat(frameHrefs);
+  }
+  return parseDocsFromHrefs(hrefs);
+}
+
+/** Select a cascading dropdown value and wait for any dependent reload. */
+async function selectAndSettle(page: Page, name: string, value: string) {
+  const selector = `select[name="${name}"]`;
+  await page.waitForSelector(selector, { timeout: 30000 });
+  await Promise.all([
+    page.waitForLoadState("domcontentloaded").catch(() => {}),
+    page.selectOption(selector, value).catch((e) => {
+      throw new Error(`Could not select ${name}="${value}": ${e.message}`);
+    }),
+  ]);
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+/** Human label for an objType. */
+function typeLabel(type: string): string {
+  switch (type) {
+    case "rm":
+      return "Repair Manual";
+    case "ewdappu":
+      return "Wiring Diagram (modern EWD)";
+    case "ewd":
+      return "Wiring Diagram (legacy)";
+    case "bm":
+      return "Body/Collision Manual";
+    case "ncf":
+      return "New Car Features";
+    default:
+      return type;
+  }
+}
+
+/** The exact downloader `-m` flag for a given objType + publication number. */
+function downloaderFlag(type: string, pub: string, year: string): string {
+  const upper2 = pub.slice(0, 2).toUpperCase();
+  switch (type) {
+    case "rm":
+      // Repair manuals support year filtering; legacy ids need an explicit type.
+      return upper2 === "RM" ? `-m ${pub}@${year}` : `-m rm:${pub}@${year}`;
+    case "ewdappu":
+      return upper2 === "EM" ? `-m ${pub}` : `-m em:${pub}`;
+    case "ewd":
+      return `-m ewd:${pub}`;
+    case "bm":
+      return upper2 === "BM" ? `-m ${pub}@${year}` : `-m bm:${pub}@${year}`;
+    default:
+      return `-m ${pub}`;
+  }
+}
+
+async function main() {
+  const opts = commandLineArgs([
+    { name: "model", type: String },
+    { name: "year", type: String },
+    { name: "division", type: String, defaultValue: "TOYOTA" },
+    { name: "har", type: String },
+  ]);
+
+  if (!opts.model || !opts.year) {
+    console.error(
+      "Usage: ts-node tools/lookupCodes.ts --model <Model> --year <Year> [--division TOYOTA] [--har <har-path>]"
+    );
+    process.exit(2);
+  }
+
+  const cookieString = resolveCookieString(opts.har);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    storageState: {
+      cookies: playwrightCookiesFromString(cookieString),
+      origins: [],
+    },
+  });
+  page.setDefaultTimeout(30000);
+
+  try {
+    await page.goto(TIS_CATALOG_URL, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(2000);
+
+    // Fail fast with a clear message if the session is dead (expired, or bumped
+    // by a concurrent login) -- otherwise the form selects never appear and we
+    // would time out cryptically.
+    if (/concurrentLoginFailure|custom-login|\/login/i.test(page.url())) {
+      throw new Error(
+        "TIS session is not valid (expired, or bumped by a concurrent login). " +
+          "Capture a fresh HAR while logged in, with no other TIS sessions open."
+      );
+    }
+
+    await selectAndSettle(page, FIELD.division, opts.division);
+    await selectAndSettle(page, FIELD.model, opts.model);
+    await selectAndSettle(page, FIELD.year, opts.year);
+
+    // Run the repair search (lands on the Repair Manual results tab).
+    await Promise.all([
+      page.waitForLoadState("domcontentloaded").catch(() => {}),
+      page
+        .click('input[value="Search"], #searchButton')
+        .catch((e) => console.error("Search click warning:", e.message)),
+    ]);
+    await page.waitForTimeout(SEARCH_SETTLE_MS);
+
+    const byType = new Map<string, Set<string>>();
+    const collect = (docs: FoundDoc[]) =>
+      docs.forEach((d) => {
+        if (!byType.has(d.type)) byType.set(d.type, new Set());
+        byType.get(d.type)!.add(d.publicationNumber);
+      });
+
+    collect(await docsOnPage(page));
+
+    // Visit every other document-type tab (lib_<type>_page) and scrape it too.
+    const currentUrl = page.url();
+    const tabHrefs: string[] = await page
+      .$$eval("a[href]", (as) =>
+        as
+          .map((a) => (a as HTMLAnchorElement).href)
+          .filter((h) => /_pageLabel=lib_[a-z]+_page/.test(h))
+      )
+      .catch(() => []);
+    const uniqueTabs = [...new Set(tabHrefs)].filter((h) => h !== currentUrl);
+    for (const href of uniqueTabs) {
+      await page.goto(href, { waitUntil: "domcontentloaded" }).catch(() => {});
+      await page.waitForTimeout(SETTLE_MS);
+      collect(await docsOnPage(page));
+    }
+
+    console.log(`\nCodes for ${opts.division} ${opts.model} ${opts.year}:`);
+    if (!byType.size) {
+      console.log("  (no documents found -- check the model/year spelling)");
+    } else {
+      const flags: string[] = [];
+      for (const [type, set] of [...byType.entries()].sort()) {
+        for (const pub of [...set].sort()) {
+          const flag = downloaderFlag(type, pub, opts.year);
+          flags.push(flag.replace(/^-m /, ""));
+          console.log(
+            `  ${typeLabel(type).padEnd(28)} ${pub.padEnd(12)} ${flag}`
+          );
+        }
+      }
+      console.log(
+        `\nDownload all:\n  yarn start ${flags.map((f) => `-m ${f}`).join(" ")}`
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/tools/lookupCodes.ts
+++ b/tools/lookupCodes.ts
@@ -32,9 +32,16 @@ const FIELD = {
 const SETTLE_MS = 2500;
 const SEARCH_SETTLE_MS = 4000;
 
-interface FoundDoc {
+export interface FoundDoc {
   type: string; // objType, e.g. "rm", "ewdappu", "bm"
   publicationNumber: string;
+}
+
+/** A division/model/year selection on the TIS repair-search form. */
+export interface VehicleSelector {
+  division: string;
+  model: string;
+  year: string;
 }
 
 /** Extract the `_pageLabel` value from a TIS portal URL, or "" if absent. */
@@ -120,23 +127,18 @@ function downloaderFlag(type: string, pub: string, year: string): string {
   }
 }
 
-async function main() {
-  const opts = commandLineArgs([
-    { name: "model", type: String },
-    { name: "year", type: String },
-    { name: "division", type: String, defaultValue: "TOYOTA" },
-    { name: "har", type: String },
-  ]);
-
-  if (!opts.model || !opts.year) {
-    console.error(
-      "Usage: ts-node tools/lookupCodes.ts --model <Model> --year <Year> [--division TOYOTA] [--har <har-path>]"
-    );
-    process.exit(2);
-  }
-
-  const cookieString = resolveCookieString(opts.har);
-
+/**
+ * Drive the TIS catalog for one vehicle and return every document it lists:
+ * select the division/model/year, run the repair search, then visit each
+ * document-type library tab and scrape the `publicationNumber`/`objType` off the
+ * result links. The returned list is de-duped by `objType:publicationNumber`.
+ *
+ * @throws if the session is invalid (expired or bumped by a concurrent login).
+ */
+export async function collectDocuments(
+  selector: VehicleSelector,
+  cookieString: string
+): Promise<FoundDoc[]> {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({
     storageState: {
@@ -160,9 +162,9 @@ async function main() {
       );
     }
 
-    await selectAndSettle(page, FIELD.division, opts.division);
-    await selectAndSettle(page, FIELD.model, opts.model);
-    await selectAndSettle(page, FIELD.year, opts.year);
+    await selectAndSettle(page, FIELD.division, selector.division);
+    await selectAndSettle(page, FIELD.model, selector.model);
+    await selectAndSettle(page, FIELD.year, selector.year);
 
     // Run the repair search (lands on the Repair Manual results tab).
     await Promise.all([
@@ -173,12 +175,9 @@ async function main() {
     ]);
     await page.waitForTimeout(SEARCH_SETTLE_MS);
 
-    const byType = new Map<string, Set<string>>();
+    const byKey = new Map<string, FoundDoc>();
     const collect = (docs: FoundDoc[]) =>
-      docs.forEach((d) => {
-        if (!byType.has(d.type)) byType.set(d.type, new Set());
-        byType.get(d.type)!.add(d.publicationNumber);
-      });
+      docs.forEach((d) => byKey.set(`${d.type}:${d.publicationNumber}`, d));
 
     collect(await docsOnPage(page));
 
@@ -210,30 +209,64 @@ async function main() {
       collect(await docsOnPage(page));
     }
 
-    console.log(`\nCodes for ${opts.division} ${opts.model} ${opts.year}:`);
-    if (!byType.size) {
-      console.log("  (no documents found -- check the model/year spelling)");
-    } else {
-      const flags: string[] = [];
-      for (const [type, set] of [...byType.entries()].sort()) {
-        for (const pub of [...set].sort()) {
-          const flag = downloaderFlag(type, pub, opts.year);
-          flags.push(flag.replace(/^-m /, ""));
-          console.log(
-            `  ${typeLabel(type).padEnd(28)} ${pub.padEnd(12)} ${flag}`
-          );
-        }
-      }
-      console.log(
-        `\nDownload all:\n  yarn start ${flags.map((f) => `-m ${f}`).join(" ")}`
-      );
-    }
+    return [...byKey.values()];
   } finally {
     await browser.close();
   }
 }
 
-main().catch((e) => {
-  console.error("ERROR:", e.message);
-  process.exit(1);
-});
+async function main() {
+  const opts = commandLineArgs([
+    { name: "model", type: String },
+    { name: "year", type: String },
+    { name: "division", type: String, defaultValue: "TOYOTA" },
+    { name: "har", type: String },
+  ]);
+
+  if (!opts.model || !opts.year) {
+    console.error(
+      "Usage: ts-node tools/lookupCodes.ts --model <Model> --year <Year> [--division TOYOTA] [--har <har-path>]"
+    );
+    process.exit(2);
+  }
+
+  const cookieString = resolveCookieString(opts.har);
+  const docs = await collectDocuments(
+    { division: opts.division, model: opts.model, year: opts.year },
+    cookieString
+  );
+
+  // Group by objType for a readable, stable listing.
+  const byType = new Map<string, Set<string>>();
+  for (const d of docs) {
+    if (!byType.has(d.type)) byType.set(d.type, new Set());
+    byType.get(d.type)!.add(d.publicationNumber);
+  }
+
+  console.log(`\nCodes for ${opts.division} ${opts.model} ${opts.year}:`);
+  if (!byType.size) {
+    console.log("  (no documents found -- check the model/year spelling)");
+    return;
+  }
+
+  const flags: string[] = [];
+  for (const [type, set] of [...byType.entries()].sort()) {
+    for (const pub of [...set].sort()) {
+      const flag = downloaderFlag(type, pub, opts.year);
+      flags.push(flag.replace(/^-m /, ""));
+      console.log(`  ${typeLabel(type).padEnd(28)} ${pub.padEnd(12)} ${flag}`);
+    }
+  }
+  console.log(
+    `\nDownload all:\n  yarn start ${flags.map((f) => `-m ${f}`).join(" ")}`
+  );
+}
+
+// Only run the CLI when invoked directly (e.g. `ts-node tools/lookupCodes.ts`),
+// not when imported for `collectDocuments` (e.g. by tools/downloadDocuments.ts).
+if (require.main === module) {
+  main().catch((e) => {
+    console.error("ERROR:", e.message);
+    process.exit(1);
+  });
+}

--- a/tools/refreshSession.ts
+++ b/tools/refreshSession.ts
@@ -30,7 +30,10 @@ import { cookieStringFromPlaywright, emitCookie } from "./lib/harCookie";
  */
 
 const LOGIN_URL = `${TIS_ORIGIN}/t3Portal/`;
-const OTP_WAIT_MS = 5 * 60 * 1000;
+// Generous window: when an orchestrator relays the OTP from a human (via
+// --otp-file), the round-trip can take several minutes. Toyota's codes stay
+// valid long enough that erring large here just avoids needless re-sends.
+const OTP_WAIT_MS = 15 * 60 * 1000;
 
 // Settle delays for the various steps of the login/SSO flow. These are the
 // values most likely to need tuning if Toyota changes the login.

--- a/tools/refreshSession.ts
+++ b/tools/refreshSession.ts
@@ -1,0 +1,217 @@
+import * as fs from "fs";
+import * as readline from "readline";
+import commandLineArgs from "command-line-args";
+import { chromium, Page } from "playwright";
+import { TIS_ORIGIN } from "../src/api/client";
+import { cookieStringFromPlaywright, emitCookie } from "./lib/harCookie";
+
+/**
+ * Mint a fresh TIS session by driving the real browser login, including Toyota's
+ * two-factor step. The tool's scripted login can't authenticate against current
+ * TIS, and the cookie from a HAR goes stale once the portal session rotates --
+ * so this is the autonomous way to (re)obtain a working session cookie.
+ *
+ * It logs in with TIS_EMAIL / TIS_PASSWORD (env), reaches the "choose a
+ * validation method" page, triggers a one-time code to your phone/email, reads
+ * the code (interactively from stdin, or from a file via --otp-file), submits
+ * it, and emits the resulting `TIS_COOKIE='...'`.
+ *
+ * Usage:
+ *   TIS_EMAIL=you@example.com TIS_PASSWORD=secret \
+ *     yarn refresh-session [--method text|email] [--out tis.env] [--otp-file path] [--headed]
+ *
+ *   # …prompts: "Enter the OTP code sent to your device:"  (unless --otp-file)
+ *
+ * 2FA requires a human-relayed code, so this cannot be fully unattended; the
+ * --otp-file option lets an orchestrator drop the code in for automation.
+ *
+ * Note: this performs a portal login, which rotates the server-side session and
+ * supersedes any previously captured cookie.
+ */
+
+const LOGIN_URL = `${TIS_ORIGIN}/t3Portal/`;
+const OTP_WAIT_MS = 5 * 60 * 1000;
+
+// Settle delays for the various steps of the login/SSO flow. These are the
+// values most likely to need tuning if Toyota changes the login.
+const CREDENTIALS_SETTLE_MS = 8000; // after submitting username/password
+const METHOD_SELECT_SETTLE_MS = 800; // after picking a validation method
+const OTP_TRIGGER_SETTLE_MS = 6000; // after triggering the one-time code
+const OTP_FILL_SETTLE_MS = 500; // after typing the code, before verifying
+const SSO_SETTLE_MS = 3000; // per portal/SSO-handshake settle iteration
+const SSO_SETTLE_ITERATIONS = 10;
+
+interface Options {
+  method: string;
+  out?: string;
+  "otp-file"?: string;
+  headed: boolean;
+}
+
+function atPortal(url: string): boolean {
+  return (
+    /\/t3Portal\/(\?|$)|_pageLabel=t3_home/.test(url) &&
+    !/login|concurrent/i.test(url)
+  );
+}
+
+/** Click the first control whose visible text/value/alt matches `re` (in-page). */
+async function clickByText(page: Page, re: string): Promise<string | null> {
+  return page
+    .evaluate((reSrc) => {
+      const rx = new RegExp(reSrc, "i");
+      const els = Array.from(
+        document.querySelectorAll(
+          "button, input[type=submit], input[type=button], input[type=image], a"
+        )
+      );
+      const hit = els.find((e: any) =>
+        rx.test((e.value || e.textContent || e.alt || e.title || "").trim())
+      );
+      if (hit) {
+        (hit as HTMLElement).click();
+        return ((hit as any).value || hit.textContent || "")
+          .trim()
+          .slice(0, 30);
+      }
+      return null;
+    }, re)
+    .catch(() => null);
+}
+
+/** Read the OTP from a file (polling) or interactively from stdin. */
+async function readOtp(otpFile?: string): Promise<string> {
+  if (otpFile) {
+    const start = Date.now();
+    while (Date.now() - start < OTP_WAIT_MS) {
+      if (fs.existsSync(otpFile)) {
+        const value = fs.readFileSync(otpFile, "utf8").trim();
+        if (value) {
+          fs.rmSync(otpFile, { force: true });
+          return value;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(`Timed out waiting for an OTP in ${otpFile}`);
+  }
+  // Interactive: prompt on stderr so stdout stays clean for the cookie output.
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  return new Promise((resolve) =>
+    rl.question("Enter the OTP code sent to your device: ", (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    })
+  );
+}
+
+async function main() {
+  const opts = commandLineArgs([
+    { name: "method", type: String, defaultValue: "text" },
+    { name: "out", type: String },
+    { name: "otp-file", type: String },
+    { name: "headed", type: Boolean, defaultValue: false },
+  ]) as Options;
+
+  const email = process.env.TIS_EMAIL;
+  const password = process.env.TIS_PASSWORD;
+  if (!email || !password) {
+    console.error("Set TIS_EMAIL and TIS_PASSWORD in the environment.");
+    process.exit(2);
+  }
+  const methodRe = /^email/i.test(opts.method) ? /email to/i : /text to/i;
+
+  const browser = await chromium.launch({ headless: !opts.headed });
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(30000);
+
+  try {
+    // 1. Credentials. The submit is an image button that won't take a synthetic
+    //    click headless, but pressing Enter in the password field submits.
+    await page.goto(LOGIN_URL, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector('input[name="username"]', { state: "visible" });
+    await page.fill('input[name="username"]', email);
+    await page.fill('input[name="password"]', password);
+    await page.press('input[name="password"]', "Enter");
+    await page.waitForTimeout(CREDENTIALS_SETTLE_MS);
+
+    // 2. Choose the validation method and trigger the one-time code.
+    await page
+      .evaluate((reSrc) => {
+        const rx = new RegExp(reSrc, "i");
+        for (const r of Array.from(
+          document.querySelectorAll("input[type=radio]")
+        )) {
+          const label =
+            (r.closest("label") && r.closest("label")!.textContent) ||
+            (r.parentElement && r.parentElement.textContent) ||
+            "";
+          if (rx.test(label)) {
+            (r as HTMLInputElement).checked = true;
+            (r as HTMLElement).click();
+            return;
+          }
+        }
+      }, methodRe.source)
+      .catch(() => {});
+    await page.waitForTimeout(METHOD_SELECT_SETTLE_MS);
+    await clickByText(page, "log ?in|send|continue|submit|next");
+    await page.waitForTimeout(OTP_TRIGGER_SETTLE_MS);
+
+    if (atPortal(page.url())) {
+      // No 2FA was required (e.g. a remembered device) -- already in.
+    } else {
+      // 3. Collect the code and submit it.
+      console.error("A one-time code was sent. Waiting for it...");
+      const otp = await readOtp(opts["otp-file"]);
+      const otpField = page
+        .locator(
+          "input[type=text]:visible, input[type=number]:visible, input[type=tel]:visible, input[type=password]:visible"
+        )
+        .first();
+      await otpField.fill(otp);
+      await page.waitForTimeout(OTP_FILL_SETTLE_MS);
+      const verified = await clickByText(
+        page,
+        "verify|log ?in|submit|continue|confirm|next"
+      );
+      if (!verified) await otpField.press("Enter").catch(() => {});
+
+      // 4. Settle through the SSO handshake to the portal.
+      for (let i = 0; i < SSO_SETTLE_ITERATIONS; i++) {
+        await page.waitForTimeout(SSO_SETTLE_MS);
+        if (atPortal(page.url())) break;
+        await clickByText(page, "continue|accept|agree|proceed|^yes$|ok\\b");
+      }
+      if (!atPortal(page.url())) {
+        await page
+          .goto(LOGIN_URL, { waitUntil: "domcontentloaded" })
+          .catch(() => {});
+        await page.waitForTimeout(SSO_SETTLE_MS);
+      }
+    }
+
+    const cookies = await ctx.cookies(`${TIS_ORIGIN}/`);
+    if (
+      !cookies.some((c) => c.name === "TISESSIONID") ||
+      !atPortal(page.url())
+    ) {
+      throw new Error(
+        `Login did not complete (url=${page.url()}). The code may have been wrong or expired.`
+      );
+    }
+
+    emitCookie(cookieStringFromPlaywright(cookies), opts.out);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Brings the tool back to life against the **current** Toyota TIS portal and
substantially expands its coverage. Since the original was written, TIS changed
auth (email/password is gone), moved some document paths, and the tool no longer
worked end-to-end for many vehicles. This branch fixes that and adds support for
the **legacy** manual format, **multi-publication** older vehicles, and the
**standalone bulletin/TSB** document class — plus four helper tools.

With these changes the tool produced complete, verified service-manual archives
for nine Toyotas spanning model years **2002–2026** (Highlander, Highlander HV,
RAV4, RAV4 HV, Sienna HV, Prius, bZ).

7 commits, 21 files, +2012 / −194. Cleanly based on `main` (no divergence).

## What's included

### Authentication (TIS changed)
- Email/password login is dead on current TIS (multi-step ForgeRock + 2FA).
  Added robust **cookie auth** (`TIS_COOKIE` env / `-c`) and **session-expiry
  detection** (`src/api/session.ts`) that aborts cleanly instead of writing
  garbage.
- `yarn refresh-session` — scripted login that triggers/consumes a 2FA OTP
  (interactive or `--otp-file`) and emits a fresh cookie.
- `yarn extract-cookie` — pull the session cookie out of a logged-in HAR.
- Cookies are written with exclusive-create (`flag:"wx"`, mode `0600`).

### Manual coverage
- **Legacy PDF manuals** (`src/legacyManual/`): older vehicles serve each page
  as a thin xhtml wrapper redirecting to a real PDF (needs `?sisuffix=ff&locale=en`).
  Auto-detected and downloaded directly over HTTP (no browser).
- **Multi-publication older vehicles**: added manual types `atm` (transmission),
  `cr` (collision/body), `ncf` (new car features), `whr` (wire-harness) on top
  of `rm`/`bm`/`em`/`ewd`. A 2002 Highlander, for example, splits across six
  publications.
- `-m <type>:<id>[@year]`; bare `RM/EM/BM` ids autodetect.

### New tools
- `yarn lookup-codes --model X --year Y` — drives the TIS catalog and lists
  every publication a vehicle has, with the exact download command for each
  (manuals vs. standalone documents listed separately).
- `yarn download-documents --model X --year Y` — downloads the standalone
  **TSBs / recalls / bulletins / training guides** (single-PDF docs, no ToC),
  skipping the multi-page manuals.

### Bug fixes
- **lookup-codes browser crash** on heavily-bulletined vehicles (tabs de-duped
  by full href — hundreds of paginated variants — instead of by `_pageLabel`).
- **ToC data loss** in `parseToC`: a single top-level `<item>` crashed parsing;
  two sibling leaves with the same display name silently overwrote each other;
  and a folder colliding with an earlier sibling leaf threw and aborted the
  whole manual. All three fixed.
- **Case-sensitive ids**: ids were force-upper-cased, breaking legacy
  publications with a lowercase revision suffix (e.g. `RM1022Ea`).
- **EWD parts**: skip parts that 404 instead of aborting, and probe the full
  `intro/system/routing/fuselist/connlist/overall` set (see attribution below).
- **Body manuals**: `BM####` now autodetects to the `cr/` path (see below).

### Refactors (DRY / single source of truth)
- Shared ToC fetch/parse (`src/manual/toc.ts`), session/file helpers
  (`src/api/{session,files}.ts`), cookie parsing (`src/api/cookies.ts`), the
  per-document fetch-wrapper→PDF step (`downloadLegacyDocumentPdf`), and the
  catalog scraper (`collectDocuments`). `TIS_HOST`/`TIS_ORIGIN` single-sourced.

## Upstream PRs incorporated (with thanks)

This branch folds in the fixes from two open PRs — reimplemented and **verified
live against current TIS**:

- **#13 by @nchen63** — EWD parts. The downloader threw "EWD doesn't exist" on
  any part 404. Confirmed live: the 2025 4Runner (`EM4430U`) 404s on
  `overall`/`intro`/`fuselist`/`connlist` and only has `system`+`routing`, so
  the old code crashed on it. Now skips 404 parts, probes the full part set,
  creates a part dir only after its `title.xml` is confirmed, and errors only if
  no part is found.
- **#9 by @mrFatDZ** — body manuals moved from `bm/` to `cr/`. Confirmed live:
  `bm/BM26L0U|BM40P0U|BM27F0U` all 404 while `cr/` returns 200. A bare `BM` id
  now autodetects to `cr` (the explicit `bm:` prefix is kept as a fallback).

## Upstream PRs superseded

These are addressed more comprehensively here and shouldn't need separate merges:

- **#2 by @skamp123** (add NM/`ncf` type) — `ncf` is included as one of the four
  new manual types.
- **#5 by @elliotmatson** (older-manual PDF download, fixes #4) — handled by the
  dedicated pure-axios `src/legacyManual/` downloader (no browser), used to
  fetch hundreds of legacy PDFs successfully.

Not included: **#14** (Axios 0.27→1.8) — never hit the zlib error it fixes, and
a major version bump risks breaking the client for no current benefit.

## Validation

There is no test framework in this repo. Validation: `tsc --noEmit` and
`prettier --check` clean on every change; an independent code-review pass; live
verification of every adopted fix; and end-to-end runs that produced verified
archives (per-page PDF counts match the ToC, no truncated files, archive
integrity checked) for 2002/2010/2012/2020/2021/2022/2026 model years.

## Notes for reviewers
- `NODE_TLS_REJECT_UNAUTHORIZED=0` is required (Node rejects Toyota's TLS cert);
  the `yarn` scripts set it.
- No secrets, cookies, or downloaded PDFs are committed (`manuals/` is gitignored).
